### PR TITLE
Minor UI fixes in Edit & Create Views

### DIFF
--- a/lib/ui/views/groups/add_assignment_view.dart
+++ b/lib/ui/views/groups/add_assignment_view.dart
@@ -248,6 +248,7 @@ class _AddAssignmentViewState extends State<AddAssignmentView> {
           child: Form(
             key: _formKey,
             child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: <Widget>[
                 _buildNameInput(),
                 _buildDescriptionInput(),

--- a/lib/ui/views/groups/edit_group_view.dart
+++ b/lib/ui/views/groups/edit_group_view.dart
@@ -59,6 +59,7 @@ class _EditGroupViewState extends State<EditGroupView> {
           child: Form(
             key: _formKey,
             child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: <Widget>[
                 CVSubheader(
                   title: 'EDIT GROUP',

--- a/lib/ui/views/groups/new_group_view.dart
+++ b/lib/ui/views/groups/new_group_view.dart
@@ -55,6 +55,7 @@ class _NewGroupViewState extends State<NewGroupView> {
           child: Form(
             key: _formKey,
             child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: <Widget>[
                 CVSubheader(
                   title: 'NEW GROUP',

--- a/lib/ui/views/groups/update_assignment_view.dart
+++ b/lib/ui/views/groups/update_assignment_view.dart
@@ -224,6 +224,7 @@ class _UpdateAssignmentViewState extends State<UpdateAssignmentView> {
           child: Form(
             key: _formKey,
             child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: <Widget>[
                 _buildNameInput(),
                 _buildDescriptionInput(),

--- a/lib/ui/views/profile/edit_profile_view.dart
+++ b/lib/ui/views/profile/edit_profile_view.dart
@@ -111,6 +111,7 @@ class _EditProfileViewState extends State<EditProfileView> {
           child: Form(
             key: _formKey,
             child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: <Widget>[
                 _buildNameInput(),
                 _buildCountryField(),

--- a/lib/ui/views/projects/edit_project_view.dart
+++ b/lib/ui/views/projects/edit_project_view.dart
@@ -148,6 +148,7 @@ class _EditProjectViewState extends State<EditProjectView> {
           child: Form(
             key: _formKey,
             child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: <Widget>[
                 _buildNameInput(),
                 _buildTagsInput(),


### PR DESCRIPTION
Fixes #13 

### Problem
The buttons were not properly stretched in edit & create views because of a column's missing property i.e `              crossAxisAlignment: CrossAxisAlignment.stretch`. 

### Solution
Added the above property to edit & create views.