### PR TITLE
UI Test: EditProfileView: Fix Test Caused due to #42 + #43

### DIFF
--- a/test/ui_tests/profile/edit_profile_view_test.dart
+++ b/test/ui_tests/profile/edit_profile_view_test.dart
@@ -7,6 +7,7 @@ import 'package:mobile_app/models/user.dart';
 import 'package:mobile_app/services/dialog_service.dart';
 import 'package:mobile_app/ui/components/cv_primary_button.dart';
 import 'package:mobile_app/ui/components/cv_text_field.dart';
+import 'package:mobile_app/ui/components/cv_typeahead_field.dart';
 import 'package:mobile_app/ui/views/profile/edit_profile_view.dart';
 import 'package:mobile_app/utils/image_test_utils.dart';
 import 'package:mobile_app/utils/router.dart';
@@ -58,10 +59,10 @@ void main() {
 
         // Finds Name, Country, Educational Institute
         expect(find.byWidgetPredicate((widget) {
-          return widget is CVTextField &&
-              (widget.label == 'Name' ||
-                  widget.label == 'Country' ||
-                  widget.label == 'Educational Institute');
+          return (widget is CVTextField && widget.label == 'Name') ||
+              (widget is CVTypeAheadField &&
+                  (widget.label == 'Country' ||
+                      widget.label == 'Educational Institute'));
         }), findsNWidgets(3));
 
         // Finds Subscribe to mail checkbox


### PR DESCRIPTION
Fixes the failure of UI Tests in mainline master branch caused due to merging #42 and #43 together. #43 switched Country and Institute Field to `CVTypeAheadField` due to which the tests failed.
