### PR TITLE
Disabled add button on empty input field of Add Collaborators form

### DIFF
--- a/lib/ui/views/projects/project_details_view.dart
+++ b/lib/ui/views/projects/project_details_view.dart
@@ -313,6 +313,7 @@ class _ProjectDetailsViewState extends State<ProjectDetailsView> {
             _model.errorMessageFor(_model.ADD_COLLABORATORS));
       }
     }
+    setState(() => _emails = null);
   }
 
   void showAddCollaboratorsDialog() {


### PR DESCRIPTION
Fixes #45 

Describe the changes you have made in this PR -
I have changed the file ```lib/ui/views/projects/project_details_view.dart``` in line number 316 , integrated the disabling of add button on empty input field

I have taken help from this [PR](https://github.com/CircuitVerse/mobile-app/pull/32)

Screenshots of the changes (If any) -
<img width="572" alt="image" src="https://user-images.githubusercontent.com/52851184/107157420-0ee24a00-69aa-11eb-9374-7faf1d0c5695.png">



Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.

