### PR TITLE
fix(ib): Add SVG Support to images.

### DIFF
--- a/lib/ui/views/ib/ib_page_view.dart
+++ b/lib/ui/views/ib/ib_page_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:markdown/markdown.dart' as md;
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:mobile_app/config/environment_config.dart';
@@ -94,11 +95,39 @@ class _IbPageViewState extends State<IbPageView> {
     launchURL(href);
   }
 
+  Widget _buildMarkdownImage(Uri uri, String title, String alt) {
+    var widgets = <Widget>[];
+
+    // SVG Support
+    if (uri.toString().endsWith('.svg')) {
+      var url = uri.toString();
+
+      if (uri.toString().startsWith('/assets')) {
+        url = EnvironmentConfig.IB_BASE_URL + url;
+      }
+
+      widgets.add(SvgPicture.network(url));
+    } else {
+      // Fallback to default Image Builder
+      return null;
+    }
+
+    // Alternate text for SVGs
+    if (alt != null) {
+      widgets.add(Text(alt));
+    }
+
+    return Column(
+      children: widgets,
+    );
+  }
+
   Widget _buildMarkdown(IbMd data) {
     return MarkdownBody(
       data: data.content,
       selectable: true,
       imageDirectory: EnvironmentConfig.IB_BASE_URL,
+      imageBuilder: _buildMarkdownImage,
       onTapLink: _onTapLink,
       blockBuilders: {
         'chapter_contents': IbChapterContentsBuilder(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: animations
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   args:
     dependency: transitive
     description:
@@ -49,7 +49,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   build_config:
     dependency: transitive
     description:
@@ -70,21 +70,21 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.6"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   built_collection:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.0"
+    version: "8.1.1"
   characters:
     dependency: transitive
     description:
@@ -140,7 +140,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.2"
+    version: "0.3.3"
   clock:
     dependency: transitive
     description:
@@ -154,7 +154,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.1.0"
   collection:
     dependency: transitive
     description:
@@ -169,6 +169,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.1+4"
   crypto:
     dependency: transitive
     description:
@@ -196,7 +203,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   datetime_picker_formfield:
     dependency: "direct main"
     description:
@@ -217,14 +224,14 @@ packages:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.2"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.0"
+    version: "6.1.2"
   fixnum:
     dependency: transitive
     description:
@@ -278,7 +285,7 @@ packages:
       name: flutter_keyboard_visibility
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.2"
+    version: "5.0.3"
   flutter_keyboard_visibility_platform_interface:
     dependency: transitive
     description:
@@ -310,7 +317,7 @@ packages:
     description:
       path: "packages/flutter_markdown"
       ref: HEAD
-      resolved-ref: "29bb87fd8fa952de825ea1149bc6f615341dbfc5"
+      resolved-ref: "1dd3519d35edb86a8352caf7a0e96bd3ef8a2380"
       url: "git://github.com/CircuitVerse/packages.git"
     source: git
     version: "0.6.2"
@@ -360,7 +367,7 @@ packages:
       name: flutter_typeahead
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.3"
+    version: "3.2.0"
   flutter_web_auth:
     dependency: transitive
     description:
@@ -386,7 +393,7 @@ packages:
       name: get
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.4"
+    version: "4.2.3"
   get_it:
     dependency: "direct main"
     description:
@@ -407,7 +414,7 @@ packages:
       name: google_sign_in
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.4"
+    version: "5.0.5"
   google_sign_in_platform_interface:
     dependency: transitive
     description:
@@ -491,21 +498,21 @@ packages:
       name: image_picker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.1+3"
+    version: "0.8.2"
   image_picker_for_web:
     dependency: transitive
     description:
       name: image_picker_for_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.1"
   image_picker_platform_interface:
     dependency: transitive
     description:
       name: image_picker_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   intl:
     dependency: "direct main"
     description:
@@ -519,7 +526,7 @@ packages:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   js:
     dependency: transitive
     description:
@@ -575,7 +582,7 @@ packages:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.10"
+    version: "5.0.11"
   nested:
     dependency: transitive
     description:
@@ -652,7 +659,7 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   pedantic:
     dependency: "direct dev"
     description:
@@ -687,7 +694,7 @@ packages:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   pool:
     dependency: transitive
     description:
@@ -701,7 +708,7 @@ packages:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.1"
   provider:
     dependency: "direct main"
     description:
@@ -736,7 +743,7 @@ packages:
       name: random_string
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0-nullsafety"
+    version: "2.3.1"
   share:
     dependency: "direct main"
     description:
@@ -792,7 +799,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.4"
+    version: "1.2.0"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -811,14 +818,14 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   source_span:
     dependency: transitive
     description:
@@ -944,7 +951,7 @@ packages:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -965,7 +972,7 @@ packages:
       name: video_player
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.6"
+    version: "2.1.10"
   video_player_platform_interface:
     dependency: transitive
     description:
@@ -1028,14 +1035,14 @@ packages:
       name: webview_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.10"
   win32:
     dependency: transitive
     description:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   xdg_directories:
     dependency: transitive
     description:


### PR DESCRIPTION
Fixes #113

Describe the changes you have made in this PR -
- Custom Image Builder that supports SVG and falls back to default for other types of images.

Screenshots of the changes (If any) -
![photo_2021-07-21_18-03-08](https://user-images.githubusercontent.com/22657113/126489087-243c3f7d-470f-4d64-bcfe-5476f00a5c4c.jpg) ![photo_2021-07-21_18-03-24](https://user-images.githubusercontent.com/22657113/126489100-2819043f-75cb-461b-bf27-80cad42a5575.jpg)


Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.
