### PR TITLE
feat(ib): Add support for Pop Quizzes.

### DIFF
--- a/lib/models/ib/ib_pop_quiz_question.dart
+++ b/lib/models/ib/ib_pop_quiz_question.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/cupertino.dart';
+
+class IbPopQuizQuestion {
+  final String question;
+  List<int> answers;
+  List<String> choices;
+
+  IbPopQuizQuestion(
+      {@required this.question,
+      @required this.answers,
+      @required this.choices});
+}

--- a/lib/models/ib/ib_pop_quiz_question.dart
+++ b/lib/models/ib/ib_pop_quiz_question.dart
@@ -5,8 +5,9 @@ class IbPopQuizQuestion {
   List<int> answers;
   List<String> choices;
 
-  IbPopQuizQuestion(
-      {@required this.question,
-      @required this.answers,
-      @required this.choices});
+  IbPopQuizQuestion({
+    @required this.question,
+    @required this.answers,
+    @required this.choices,
+  });
 }

--- a/lib/services/ib_engine_service.dart
+++ b/lib/services/ib_engine_service.dart
@@ -244,7 +244,7 @@ class IbEngineServiceImpl implements IbEngineService {
       pageUrl: _ibRawPageData.httpUrl,
       title: _ibRawPageData.title,
       content: [
-        IbMd(content: HtmlUnescape().convert(_ibRawPageData.rawContent)),
+        IbMd(content: HtmlUnescape().convert(_ibRawPageData.rawContent) + '\n'),
       ],
       tableOfContents: _ibRawPageData.hasToc
           ? _getTableOfContents(_ibRawPageData.content)

--- a/lib/ui/views/ib/builders/ib_interaction_builder.dart
+++ b/lib/ui/views/ib/builders/ib_interaction_builder.dart
@@ -8,10 +8,9 @@ import 'package:mobile_app/viewmodels/ib/ib_page_viewmodel.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 class IbInteractionBuilder extends MarkdownElementBuilder {
-  final BuildContext context;
   final IbPageViewModel model;
 
-  IbInteractionBuilder({this.context, this.model});
+  IbInteractionBuilder({this.model});
 
   @override
   Widget visitElementAfter(md.Element element, TextStyle preferredStyle) {
@@ -32,27 +31,28 @@ class IbInteractionBuilder extends MarkdownElementBuilder {
         WebViewController _webViewController;
 
         return StreamBuilder<double>(
-            initialData: 100,
-            stream: _streamController.stream,
-            builder: (context, snapshot) {
-              return Container(
-                height: snapshot.data,
-                child: WebView(
-                  initialUrl:
-                      'data:text/html;base64,${base64Encode(const Utf8Encoder().convert(_textContent))}',
-                  onPageFinished: (some) async {
-                    var height = double.parse(
-                        await _webViewController.evaluateJavascript(
-                            'document.documentElement.scrollHeight;'));
-                    _streamController.add(height);
-                  },
-                  onWebViewCreated: (_controller) {
-                    _webViewController = _controller;
-                  },
-                  javascriptMode: JavascriptMode.unrestricted,
-                ),
-              );
-            });
+          initialData: 100,
+          stream: _streamController.stream,
+          builder: (context, snapshot) {
+            return Container(
+              height: snapshot.data,
+              child: WebView(
+                initialUrl:
+                    'data:text/html;base64,${base64Encode(const Utf8Encoder().convert(_textContent))}',
+                onPageFinished: (some) async {
+                  var height = double.parse(
+                      await _webViewController.evaluateJavascript(
+                          'document.documentElement.scrollHeight;'));
+                  _streamController.add(height);
+                },
+                onWebViewCreated: (_controller) {
+                  _webViewController = _controller;
+                },
+                javascriptMode: JavascriptMode.unrestricted,
+              ),
+            );
+          },
+        );
       },
     );
   }

--- a/lib/ui/views/ib/builders/ib_pop_quiz_builder.dart
+++ b/lib/ui/views/ib/builders/ib_pop_quiz_builder.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:markdown/markdown.dart' as md;
+import 'package:mobile_app/ui/views/ib/components/ib_pop_quiz.dart';
+import 'package:mobile_app/viewmodels/ib/ib_page_viewmodel.dart';
+
+class IbPopQuizBuilder extends MarkdownElementBuilder {
+  final BuildContext context;
+  final IbPageViewModel model;
+
+  IbPopQuizBuilder({this.context, this.model});
+
+  @override
+  Widget visitElementAfter(md.Element element, TextStyle preferredStyle) {
+    var _rawContent = element.textContent;
+    var _popQuizQuestions = model.fetchPopQuiz(_rawContent);
+
+    return IbPopQuiz(
+      context: context,
+      questions: _popQuizQuestions,
+    );
+  }
+}

--- a/lib/ui/views/ib/builders/ib_webview_builder.dart
+++ b/lib/ui/views/ib/builders/ib_webview_builder.dart
@@ -6,9 +6,7 @@ import 'package:webview_flutter/webview_flutter.dart';
 import 'package:markdown/markdown.dart' as md;
 
 class IbWebViewBuilder extends MarkdownElementBuilder {
-  final BuildContext context;
-
-  IbWebViewBuilder({this.context});
+  IbWebViewBuilder();
 
   @override
   Widget visitElementAfter(md.Element element, TextStyle preferredStyle) {

--- a/lib/ui/views/ib/components/ib_pop_quiz.dart
+++ b/lib/ui/views/ib/components/ib_pop_quiz.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:mobile_app/ib_theme.dart';
+import 'package:mobile_app/models/ib/ib_pop_quiz_question.dart';
+import 'package:mobile_app/ui/views/ib/components/ib_pop_quiz_button.dart';
+
+class IbPopQuiz extends StatelessWidget {
+  final BuildContext context;
+  final List<IbPopQuizQuestion> questions;
+
+  IbPopQuiz({this.context, this.questions});
+
+  Widget _buildQuestion(int questionNumber, IbPopQuizQuestion question) {
+    var buttonsWidgets = <Widget>[];
+
+    for (var i = 0; i < question.choices.length; i++) {
+      buttonsWidgets.add(
+        IbPopQuizButton(
+          content: question.choices[i],
+          isCorrect: question.answers.contains(i),
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Question $questionNumber',
+            textAlign: TextAlign.start,
+            style: Theme.of(context).textTheme.subtitle2,
+          ),
+          Padding(
+            padding: const EdgeInsets.only(top: 6.0),
+            child: MarkdownBody(data: question.question),
+          ),
+          ...buttonsWidgets,
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var questionsWidgets = <Widget>[];
+
+    for (var i = 0; i < questions.length; i++) {
+      questionsWidgets.add(_buildQuestion(i + 1, questions[i]));
+    }
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8.0),
+          child: Text(
+            'Pop Quiz',
+            style: Theme.of(context).textTheme.headline5.copyWith(
+                  color: IbTheme.primaryHeadingColor(context),
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
+        ),
+        ...questionsWidgets,
+      ],
+    );
+  }
+}

--- a/lib/ui/views/ib/components/ib_pop_quiz_button.dart
+++ b/lib/ui/views/ib/components/ib_pop_quiz_button.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+
+class IbPopQuizButton extends StatefulWidget {
+  final String content;
+  final bool isCorrect;
+
+  IbPopQuizButton({
+    @required this.content,
+    @required this.isCorrect,
+  });
+
+  @override
+  IbPopQuizButtonState createState() => IbPopQuizButtonState();
+}
+
+class IbPopQuizButtonState extends State<IbPopQuizButton> {
+  bool _isPressed = false;
+
+  Color _getTextColor() {
+    if (_isPressed) {
+      return Colors.white;
+    }
+
+    return Theme.of(context).textTheme.bodyText1.color;
+  }
+
+  Color _getBorderColor() {
+    if (_isPressed) {
+      if (widget.isCorrect) {
+        return Colors.green[400];
+      } else {
+        return Colors.red[400];
+      }
+    }
+
+    return Theme.of(context).textTheme.bodyText1.color;
+  }
+
+  IconData getTheRightIcon() {
+    return widget.isCorrect ? Icons.done : Icons.close;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () => setState(() {
+        _isPressed = !_isPressed;
+      }),
+      child: Container(
+        margin: EdgeInsets.only(top: 5.0),
+        padding: EdgeInsets.all(10.0),
+        decoration: BoxDecoration(
+          color: _isPressed ? _getBorderColor() : null,
+          border: Border.all(color: _getBorderColor()),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              widget.content,
+              style: TextStyle(color: _getTextColor(), fontSize: 16),
+            ),
+            _isPressed
+                ? Container(
+                    height: 19,
+                    width: 19,
+                    decoration: BoxDecoration(
+                      color: _getTextColor(),
+                      borderRadius: BorderRadius.circular(50),
+                      border: Border.all(color: _getBorderColor()),
+                    ),
+                    child: Icon(
+                      getTheRightIcon(),
+                      size: 16,
+                      color: _getBorderColor(),
+                    ),
+                  )
+                : Container(),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/views/ib/ib_page_view.dart
+++ b/lib/ui/views/ib/ib_page_view.dart
@@ -11,6 +11,7 @@ import 'package:mobile_app/models/ib/ib_page_data.dart';
 import 'package:mobile_app/ui/views/base_view.dart';
 import 'package:mobile_app/ui/views/ib/builders/ib_chapter_contents_builder.dart';
 import 'package:mobile_app/ui/views/ib/builders/ib_interaction_builder.dart';
+import 'package:mobile_app/ui/views/ib/builders/ib_pop_quiz_builder.dart';
 import 'package:mobile_app/ui/views/ib/builders/ib_webview_builder.dart';
 import 'package:mobile_app/ui/views/ib/syntaxes/ib_embed_syntax.dart';
 import 'package:mobile_app/ui/views/ib/syntaxes/ib_filter_syntax.dart';
@@ -137,6 +138,7 @@ class _IbPageViewState extends State<IbPageView> {
                 : Container()),
         'iframe': IbWebViewBuilder(context: context),
         'interaction': IbInteractionBuilder(model: _model),
+        'quiz': IbPopQuizBuilder(context: context, model: _model),
       },
       extensionSet: md.ExtensionSet(
         [

--- a/lib/ui/views/ib/ib_page_view.dart
+++ b/lib/ui/views/ib/ib_page_view.dart
@@ -136,7 +136,7 @@ class _IbPageViewState extends State<IbPageView> {
                     false
                 ? _buildTOC(_model.pageData.chapterOfContents, padding: false)
                 : Container()),
-        'iframe': IbWebViewBuilder(context: context),
+        'iframe': IbWebViewBuilder(),
         'interaction': IbInteractionBuilder(model: _model),
         'quiz': IbPopQuizBuilder(context: context, model: _model),
       },

--- a/lib/ui/views/ib/syntaxes/ib_md_tag_syntax.dart
+++ b/lib/ui/views/ib/syntaxes/ib_md_tag_syntax.dart
@@ -24,14 +24,16 @@ class IbMdTagSyntax extends md.BlockSyntax {
 
     // (TODO) Fix Pop Quizes
     if (_tagsStack.contains('.quiz')) {
-      // Ignore parsing quiz content
+      var quizContent = '';
+
+      // Eat all quiz content
       do {
+        quizContent += '\n${parser.current}';
         parser.advance();
-      } while (!parser.isDone);
+      } while (parser.next != null || !parser.isDone);
 
       _tagsStack.remove('.quiz');
-
-      return null;
+      return md.Element.text('quiz', quizContent);
     }
 
     parser.advance();

--- a/lib/viewmodels/ib/ib_page_viewmodel.dart
+++ b/lib/viewmodels/ib/ib_page_viewmodel.dart
@@ -2,6 +2,7 @@ import 'package:mobile_app/enums/view_state.dart';
 import 'package:mobile_app/locator.dart';
 import 'package:mobile_app/models/failure_model.dart';
 import 'package:mobile_app/models/ib/ib_page_data.dart';
+import 'package:mobile_app/models/ib/ib_pop_quiz_question.dart';
 import 'package:mobile_app/services/ib_engine_service.dart';
 import 'package:mobile_app/viewmodels/base_viewmodel.dart';
 
@@ -9,6 +10,7 @@ class IbPageViewModel extends BaseModel {
   // ViewState Keys
   String IB_FETCH_PAGE_DATA = 'ib_fetch_page_data';
   String IB_FETCH_INTERACTION_DATA = 'ib_fetch_interaction_data';
+  String IB_FETCH_POP_QUIZ = 'ib_fetch_pop_quiz';
 
   final IbEngineService _ibEngineService = locator<IbEngineService>();
 
@@ -34,6 +36,18 @@ class IbPageViewModel extends BaseModel {
     } on Failure catch (f) {
       setStateFor(IB_FETCH_INTERACTION_DATA, ViewState.Error);
       setErrorMessageFor(IB_FETCH_INTERACTION_DATA, f.message);
+    }
+  }
+
+  List<IbPopQuizQuestion> fetchPopQuiz(String rawContent) {
+    try {
+      var result = _ibEngineService.getPopQuiz(rawContent);
+      setStateFor(IB_FETCH_POP_QUIZ, ViewState.Success);
+      return result;
+    } on Failure catch (f) {
+      setStateFor(IB_FETCH_POP_QUIZ, ViewState.Error);
+      setErrorMessageFor(IB_FETCH_POP_QUIZ, f.message);
+      return [];
     }
   }
 }

--- a/test/service_tests/ib_engine_test.dart
+++ b/test/service_tests/ib_engine_test.dart
@@ -9,6 +9,7 @@ import 'package:mobile_app/models/failure_model.dart';
 import 'package:mobile_app/models/ib/ib_chapter.dart';
 import 'package:mobile_app/models/ib/ib_content.dart';
 import 'package:mobile_app/models/ib/ib_page_data.dart';
+import 'package:mobile_app/models/ib/ib_pop_quiz_question.dart';
 import 'package:mobile_app/models/ib/ib_raw_page_data.dart';
 import 'package:mobile_app/services/ib_engine_service.dart';
 import 'package:mobile_app/utils/api_utils.dart';
@@ -249,6 +250,78 @@ void main() {
         var _actualResult = await _ibEngine.getHtmlInteraction('binary.html');
 
         expect(_expectedResult, _actualResult);
+      });
+    });
+
+    group('getPopQuiz -', () {
+      test('When a quiz is called and returns success response', () async {
+        var _mockPopContent = '''
+1. An ALU having `n` selection lines can provide upto _____ operations.
+  * 2n
+  * n / 2
+  1. 2^n
+2. Input data can flow in parallel to multiple units inside the ALU.
+  1. True
+  * False
+3. The data is stored in which of the following before ALU accesses it for operation ?
+  * ROM memory
+  1. Internal registers
+  * RAM memory
+''';
+
+        var _actualResult = <IbPopQuizQuestion>[
+          IbPopQuizQuestion(
+            question:
+                'An ALU having `n` selection lines can provide upto _____ operations.',
+            answers: [2],
+            choices: ['2n', 'n / 2', '2^n'],
+          ),
+          IbPopQuizQuestion(
+            question:
+                'Input data can flow in parallel to multiple units inside the ALU.',
+            answers: [0],
+            choices: ['True', 'False'],
+          ),
+          IbPopQuizQuestion(
+            question:
+                'The data is stored in which of the following before ALU accesses it for operation ?',
+            answers: [1],
+            choices: ['ROM memory', 'Internal registers', 'RAM memory'],
+          ),
+        ];
+
+        var _ibEngine = IbEngineServiceImpl();
+        var _expectedResult = _ibEngine.getPopQuiz(_mockPopContent);
+
+        expect(_expectedResult.length, _actualResult.length);
+        expect(_expectedResult[0].question, _actualResult[0].question);
+        expect(
+            _expectedResult[0].answers.length, _actualResult[0].answers.length);
+        expect(_expectedResult[0].answers[0], _actualResult[0].answers[0]);
+        expect(
+            _expectedResult[0].choices.length, _actualResult[0].choices.length);
+        expect(_expectedResult[0].choices[0], _expectedResult[0].choices[0]);
+        expect(_expectedResult[0].choices[1], _expectedResult[0].choices[1]);
+        expect(_expectedResult[0].choices[2], _expectedResult[0].choices[2]);
+
+        expect(_expectedResult[1].question, _actualResult[1].question);
+        expect(
+            _expectedResult[1].answers.length, _actualResult[1].answers.length);
+        expect(_expectedResult[1].answers[0], _actualResult[1].answers[0]);
+        expect(
+            _expectedResult[1].choices.length, _actualResult[1].choices.length);
+        expect(_expectedResult[1].choices[0], _expectedResult[1].choices[0]);
+        expect(_expectedResult[1].choices[1], _expectedResult[1].choices[1]);
+
+        expect(_expectedResult[2].question, _actualResult[2].question);
+        expect(
+            _expectedResult[2].answers.length, _actualResult[2].answers.length);
+        expect(_expectedResult[2].answers[0], _actualResult[2].answers[0]);
+        expect(
+            _expectedResult[2].choices.length, _actualResult[2].choices.length);
+        expect(_expectedResult[2].choices[0], _expectedResult[2].choices[0]);
+        expect(_expectedResult[2].choices[1], _expectedResult[2].choices[1]);
+        expect(_expectedResult[2].choices[2], _expectedResult[2].choices[2]);
       });
     });
   });

--- a/test/service_tests/ib_engine_test.dart
+++ b/test/service_tests/ib_engine_test.dart
@@ -91,7 +91,7 @@ void main() {
           id: mockIbRawPageData1['name'],
           pageUrl: mockIbRawPageData1['http_url'],
           title: mockIbRawPageData1['title'],
-          content: [IbMd(content: mockIbRawPageData1['raw_content'])],
+          content: [IbMd(content: mockIbRawPageData1['raw_content'] + '\n')],
           tableOfContents: [],
         );
 

--- a/test/viewmodel_tests/ib/ib_page_viewmodel_test.dart
+++ b/test/viewmodel_tests/ib/ib_page_viewmodel_test.dart
@@ -86,5 +86,35 @@ void main() {
             _model.stateFor(_model.IB_FETCH_INTERACTION_DATA), ViewState.Error);
       });
     });
+
+    group('fetchPopQuiz -', () {
+      test('When called & service returns success response', () async {
+        var _mockIbEngineApi = getAndRegisterIbEngineServiceMock();
+        when(_mockIbEngineApi.getPopQuiz('')).thenReturn([]);
+
+        var _model = IbPageViewModel();
+        var _result = _model.fetchPopQuiz('');
+
+        // verify call to IbEngineService was made
+        verify(_mockIbEngineApi.getPopQuiz(''));
+        expect(_model.stateFor(_model.IB_FETCH_POP_QUIZ), ViewState.Success);
+
+        // verify returned data
+        expect(_result, []);
+      });
+
+      test('When called & service returns error', () async {
+        var _mockIbEngineApi = getAndRegisterIbEngineServiceMock();
+        when(_mockIbEngineApi.getPopQuiz(''))
+            .thenThrow(Failure('Some Error Occurred!'));
+
+        var _model = IbPageViewModel();
+        _model.fetchPopQuiz('');
+
+        // verify call to IbEngineService was made
+        verify(_mockIbEngineApi.getPopQuiz(''));
+        expect(_model.stateFor(_model.IB_FETCH_POP_QUIZ), ViewState.Error);
+      });
+    });
   });
 }


### PR DESCRIPTION
Adds Support for Pop Quizzes using custom Markdown Builder and using `{:quiz}` markdown syntax. 

Describe the changes you have made in this PR -
1. Allow consuming raw markdown pop quiz content from `IbMdSyntax`.
2. Develop Pop Quiz Builder and it's UI components to build Pop Quiz Questions.
3. Add parsing pop quiz logic in Ib Engine Service and correspondingly to Ib Page View Model to fetch pop quiz questions.

Screenshots of the changes (If any) -
![photo_2021-07-24_15-02-14 (1)](https://user-images.githubusercontent.com/22657113/126864426-6cc1f282-1d4f-4cf8-863b-fbd3b4767f27.jpg)

