### PR TITLE
Replaced flutter-icons with fluttericon

### DIFF
--- a/lib/ui/views/authentication/components/auth_options_view.dart
+++ b/lib/ui/views/authentication/components/auth_options_view.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_icons/flutter_icons.dart';
+import 'package:fluttericon/fluttericon.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/ui/views/base_view.dart';
 import 'package:mobile_app/ui/views/cv_landing_view.dart';

--- a/lib/ui/views/cv_landing_view.dart
+++ b/lib/ui/views/cv_landing_view.dart
@@ -1,6 +1,6 @@
 import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_icons/flutter_icons.dart';
+import 'package:fluttericon/fluttericon.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/cv_theme.dart';
 import 'package:mobile_app/locator.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -276,9 +276,9 @@ packages:
     dependency: "direct main"
     description:
       name: fluttericon
-      url: "https://pub.dartlang.org"
+      url: "https://pub.dev/packages/fluttericon"
     source: hosted
-    version: "1.1.0"
+    version: "2.0.0"
   flutter_keyboard_visibility:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -272,10 +272,10 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
-  flutter_icons:
+  fluttericon:
     dependency: "direct main"
     description:
-      name: flutter_icons
+      name: fluttericon
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   datetime_picker_formfield: ^2.0.0
   flutter_facebook_auth: ^3.5.0
   flutter_html: ^2.0.0
-  flutter_icons: ^1.1.0
+  fluttericon: ^1.1.0
   flutter_keyboard_visibility: ^5.0.2
   flutter_summernote: ^1.0.0
   flutter_svg: ^0.22.0
@@ -67,7 +67,7 @@ dependency_overrides:
   mime: ^0.9.7
   plugin_platform_interface: ^2.0.0
 
-flutter_icons:
+fluttericon:
   android: "launcher_icon"
   ios: true
   image_path: "assets/icons/icon.png"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   datetime_picker_formfield: ^2.0.0
   flutter_facebook_auth: ^3.5.0
   flutter_html: ^2.0.0
-  fluttericon: ^1.1.0
+  fluttericon: ^2.0.0
   flutter_keyboard_visibility: ^5.0.2
   flutter_summernote: ^1.0.0
   flutter_svg: ^0.22.0


### PR DESCRIPTION
Fixes #119 

Describe the changes you have made in this PR -
I have replaced all the occurences of `flutter_icons` with `fluttericon`, as stated in the issue. The `fluttericon` now refers to the following given library [fluttericon 2.0.0](https://pub.dev/packages/fluttericon).

Screenshots of the changes (If any) -

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.
