### PR TITLE
feat(commitlint): enforce commit linting via git hooks

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+green='\e[0;32m'
+red='\033[0;31m'
+nocol='\033[0m'
+
+echo -e "${green}CV: Running Commit lint${nocol}"
+npx --no-install commitlint --edit "$1"
+
+if [ $? -ne 0 ]; then
+    echo -e "${red}CV: Commit lint failed. Please fix the errors and run the command again${nocol}"
+    exit 1
+fi
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -13,16 +13,29 @@ Follow these instructions to build and run the project
 
 A detailed guide for multiple platforms setup could be find [here](https://flutter.dev/docs/get-started/install/)
 
-### Next Steps
+### Setup Project
 
-- Clone this repository.
+- Clone this repository using `git clone https://github.com/CircuitVerse/mobile-app.git`.
 - `cd` into `mobile_app`.
 - `flutter pub get` to get all the dependencies.
-- `flutter run`
+- Generate files using Builder Runner (**required**) 
+```
+flutter packages pub run --no-sound-null-safety build_runner build
+```
+- Switch to mobile-app's git hooks (**optional but recommended**)
+```
+git config core.hooksPath .githooks/
 
-### Generating Files using Build Runner
+# Make sure npm is installed to run the next command
+npm install -g @commitlint/config-conventional @commitlint/cli
+```
+> Mobile App enforces [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/), make sure to read and follow them.
 
-`flutter packages pub run --no-sound-null-safety build_runner build`
+### Running the app
+
+Make sure you have a connected Android/iOS device/simulator and run the following command to build and run the app in debug mode.
+
+`flutter run`
 
 ### Android OAuth Config
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ['@commitlint/config-conventional'] }


### PR DESCRIPTION
Describe the changes you have made in this PR -
- Added git's `commit-msg` hook in `.githooks/commit-msg`.
- To use our custom githooks directory, we need to run `git config core.hooksPath .githooks/`.
- `commitlint` should be installed globally to be able to run linting.
- Added commit linting setup step in README.md

Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/22657113/128183614-50b0f0c1-6aff-408f-a213-d97ba0f74040.png)
![image](https://user-images.githubusercontent.com/22657113/128183649-0c05a118-750e-4f95-b8cd-d874d9b1148c.png)
![image](https://user-images.githubusercontent.com/22657113/128183734-e4ded900-9431-4ba9-a35b-cec3f8549ab0.png)


