### PR TITLE
feat(cd): enable deployments via GitHub releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,9 +15,12 @@ jobs:
   deploy:
     # This job will run on ubuntu virtual machine
     runs-on: ubuntu-latest
+    # This job will run if the release is based on master branch
+    if: github.event.release.target_commitish == 'master'
     steps:
       - uses: actions/checkout@v1
 
+      # Extract the release type
       - name: set release type
         id: release
         run: echo ::set-output name=type::${{ endsWith(github.event.release.tag_name, 'beta') && 'beta' || 'prod' }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,7 +23,7 @@ jobs:
       # Extract the release type
       - name: set release type
         id: release
-        run: echo ::set-output name=type::${{ endsWith(github.event.release.tag_name, 'beta') && 'beta' || 'prod' }}
+        run: echo ::set-output name=type::${{ contains(github.event.release.tag_name, 'beta') && 'beta' || 'prod' }}
 
       # Setup Java environment in order to build the Android apps
       - uses: actions/setup-java@v1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,6 @@
 name: CD
 
-on:
-  push:
-    branches:
-      - deploy
+on: [release]
 
 env:
   FB_APP_ID: ${{ secrets.FB_APP_ID }}
@@ -19,8 +16,13 @@ jobs:
     # This job will run on ubuntu virtual machine
     runs-on: ubuntu-latest
     steps:
-      # Setup Java environment in order to build the Android app.
       - uses: actions/checkout@v1
+
+      - name: set release type
+        id: release
+        run: echo ::set-output name=type::${{ endsWith(github.event.release.tag_name, 'beta') && 'beta' || 'prod' }}
+
+      # Setup Java environment in order to build the Android apps
       - uses: actions/setup-java@v1
         with:
           java-version: "12.x"
@@ -60,8 +62,8 @@ jobs:
       # Build appbundle.
       - run: flutter build appbundle --dart-define=FB_APP_ID=${FB_APP_ID} --dart-define=FB_APP_NAME=${FB_APP_NAME} --dart-define=GITHUB_OAUTH_CLIENT_ID=${GITHUB_OAUTH_CLIENT_ID} --dart-define=GITHUB_OAUTH_CLIENT_SECRET=${GITHUB_OAUTH_CLIENT_SECRET}
 
-      # Run fastlane internal
+      # Ship the appbundle.
       - uses: maierj/fastlane-action@v1.4.0
         with:
-          lane: internal
+          lane: ${{ release.outputs.type }}
           subdirectory: android

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -16,10 +16,18 @@
 default_platform(:android)
 
 platform :android do
-  desc "Push a new internal build to Play Store"
-  lane :internal do
+  desc "Push a new beta build to Play Store"
+  lane :beta do
     upload_to_play_store(
-      track: "internal",
+      track: "beta",
+      aab: "../build/app/outputs/bundle/release/app-release.aab"
+    )
+  end
+
+  desc "Push a new production build to Play Store"
+  lane :prod do
+    upload_to_play_store(
+      track: "production",
       aab: "../build/app/outputs/bundle/release/app-release.aab"
     )
   end


### PR DESCRIPTION
Describe the changes you have made in this PR -
- Uses GitHub releases & associated tags to ship the app to play store.
- gh-actions accepts 'vx.y.z-beta' for beta builds and 'vx.y.z' for prod builds.

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.
