### PR TITLE
fix(119): swap `flutter_icons` with `fluttericon`

### DIFF
--- a/lib/ui/views/authentication/components/auth_options_view.dart
+++ b/lib/ui/views/authentication/components/auth_options_view.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_icons/flutter_icons.dart';
+import 'package:fluttericon/font_awesome5_icons.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/ui/views/base_view.dart';
 import 'package:mobile_app/ui/views/cv_landing_view.dart';
@@ -97,7 +97,7 @@ class _AuthOptionsViewState extends State<AuthOptionsView> {
                 child: Container(
                   padding: const EdgeInsets.all(8),
                   decoration: BoxDecoration(shape: BoxShape.circle),
-                  child: Icon(FontAwesome.github, size: 40),
+                  child: Icon(FontAwesome5.github, size: 40),
                 ),
               ),
             ],

--- a/lib/ui/views/cv_landing_view.dart
+++ b/lib/ui/views/cv_landing_view.dart
@@ -1,6 +1,7 @@
 import 'package:animations/animations.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_icons/flutter_icons.dart';
+import 'package:fluttericon/font_awesome5_icons.dart';
+import 'package:fluttericon/font_awesome_icons.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/cv_theme.dart';
 import 'package:mobile_app/locator.dart';
@@ -185,8 +186,7 @@ class _CVLandingViewState extends State<CVLandingView> {
                           InkWell(
                             onTap: onLogoutPressed,
                             child: CVDrawerTile(
-                                title: 'Log Out',
-                                iconData: Ionicons.ios_log_out),
+                                title: 'Log Out', iconData: FontAwesome.logout),
                           ),
                         ],
                       ),
@@ -194,7 +194,7 @@ class _CVLandingViewState extends State<CVLandingView> {
                   : InkWell(
                       onTap: () => Get.offAndToNamed(LoginView.id),
                       child: CVDrawerTile(
-                          title: 'Login', iconData: Ionicons.ios_log_in),
+                          title: 'Login', iconData: FontAwesome.login),
                     )
             ],
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -272,13 +272,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
-  flutter_icons:
-    dependency: "direct main"
-    description:
-      name: flutter_icons
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
   flutter_keyboard_visibility:
     dependency: "direct main"
     description:
@@ -380,6 +373,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  fluttericon:
+    dependency: "direct main"
+    description:
+      name: fluttericon
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   frontend_server_client:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   datetime_picker_formfield: ^2.0.0
   flutter_facebook_auth: ^3.5.0
   flutter_html: ^2.0.0
-  flutter_icons: ^1.1.0
+  fluttericon: ^2.0.0
   flutter_keyboard_visibility: ^5.0.2
   flutter_summernote: ^1.0.0
   flutter_svg: ^0.22.0


### PR DESCRIPTION
Icon designs remain same except fill/outline effects.

Fixes #119

Screenshots of the changes -
From -> To
![129544562-2e6db7a4-56ae-4021-b9a0-82adf962a7fd 1](https://user-images.githubusercontent.com/22657113/129544702-fd4ca306-eae6-45f6-993f-44f8d2b4b34b.png) to ![129544570-82411e46-2a95-4180-a2cc-13b2d7f25171 1](https://user-images.githubusercontent.com/22657113/129544970-49aa1d98-cead-4ecc-9794-73f0a88e4328.png)

