### PR TITLE
fix(lints): enable linter rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,7 +7,26 @@ linter:
   rules:
     # Util classes
     avoid_classes_with_only_static_members: false
-
     non_constant_identifier_names: false
-
     constant_identifier_names: false
+    always_declare_return_types: true
+    avoid_print: true
+    avoid_unnecessary_containers: true
+    prefer_if_elements_to_conditional_expressions: true
+    prefer_const_constructors: true
+    prefer_const_declarations: true
+    unnecessary_string_interpolations: true
+    sized_box_for_whitespace: true
+    prefer_single_quotes: true
+    prefer_const_constructors_in_immutables: true
+    use_key_in_widget_constructors: true
+    prefer_function_declarations_over_variables: true
+    unnecessary_string_escapes: true
+    avoid_function_literals_in_foreach_calls: true
+    prefer_interpolation_to_compose_strings: true
+    unnecessary_parenthesis: true
+    sort_constructors_first: true
+    always_put_required_named_parameters_first: true
+    avoid_redundant_argument_values: true
+    join_return_with_assignment: true
+

--- a/lib/models/assignments.dart
+++ b/lib/models/assignments.dart
@@ -88,17 +88,17 @@ class AssignmentAttributes {
       );
 
   AssignmentAttributes({
-    this.name,
     required this.deadline,
-    this.description,
     required this.hasMentorAccess,
+    required this.gradingScale,
+    required this.restrictions,
+    this.name,
+    this.description,
     this.createdAt,
     this.updatedAt,
     this.status,
     this.currentUserProjectId,
-    required this.gradingScale,
     this.gradesFinalized,
-    required this.restrictions,
   });
 
   String? name;

--- a/lib/models/cv_contributors.dart
+++ b/lib/models/cv_contributors.dart
@@ -30,13 +30,14 @@ class CircuitVerseContributor {
         contributions: json['contributions'],
       );
   CircuitVerseContributor({
-    this.login,
     required this.id,
-    this.nodeId,
     required this.avatarUrl,
+    required this.htmlUrl,
+    required this.contributions,
+    this.nodeId,
+    this.login,
     this.gravatarId,
     this.url,
-    required this.htmlUrl,
     this.followersUrl,
     this.followingUrl,
     this.gistsUrl,
@@ -48,7 +49,6 @@ class CircuitVerseContributor {
     this.receivedEventsUrl,
     this.type,
     this.siteAdmin,
-    required this.contributions,
   });
 
   String? login;

--- a/lib/models/grade.dart
+++ b/lib/models/grade.dart
@@ -1,8 +1,8 @@
 class Grade {
   Grade({
     required this.id,
-    this.type,
     required this.attributes,
+    this.type,
     this.relationships,
   });
   factory Grade.fromJson(Map<String, dynamic> json) => Grade(
@@ -28,8 +28,8 @@ class GradeAttributes {
       );
   GradeAttributes({
     required this.grade,
-    this.remarks,
     required this.createdAt,
+    this.remarks,
     this.updatedAt,
   });
 

--- a/lib/models/ib/ib_raw_page_data.dart
+++ b/lib/models/ib/ib_raw_page_data.dart
@@ -25,17 +25,17 @@ class IbRawPageData {
   IbRawPageData({
     required this.id,
     required this.title,
-    this.name,
-    this.content,
     required this.rawContent,
-    this.navOrder,
-    this.cvibLevel,
-    this.parent,
     required this.hasChildren,
     required this.hasToc,
     required this.disableComments,
     required this.frontMatter,
     required this.httpUrl,
+    this.name,
+    this.content,
+    this.navOrder,
+    this.cvibLevel,
+    this.parent,
     this.apiUrl,
   });
 

--- a/lib/models/ib/ib_showcase.dart
+++ b/lib/models/ib/ib_showcase.dart
@@ -1,8 +1,6 @@
 import 'dart:convert';
 
 class IBShowCase {
-  bool nextButton, prevButton, tocButton, drawerButton;
-
   IBShowCase({
     required this.nextButton,
     required this.prevButton,
@@ -18,6 +16,8 @@ class IBShowCase {
       drawerButton: json['drawer'] ?? false,
     );
   }
+
+  bool nextButton, prevButton, tocButton, drawerButton;
 
   IBShowCase copyWith({
     bool? nextButton,

--- a/lib/models/projects.dart
+++ b/lib/models/projects.dart
@@ -78,12 +78,12 @@ class ProjectAttributes {
     required this.createdAt,
     required this.updatedAt,
     required this.imagePreview,
-    this.description,
     required this.view,
     required this.tags,
-    this.isStarred,
     required this.authorName,
     required this.starsCount,
+    this.isStarred,
+    this.description,
   });
 
   String name;

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -51,12 +51,12 @@ class UserAttributes {
       );
 
   UserAttributes({
-    this.name,
+    required this.admin,
     required this.email,
     required this.subscribed,
     this.createdAt,
+    this.name,
     this.updatedAt,
-    required this.admin,
     this.country,
     this.educationalInstitute,
   });

--- a/lib/ui/components/cv_password_field.dart
+++ b/lib/ui/components/cv_password_field.dart
@@ -36,7 +36,6 @@ class _CVPasswordFieldState extends State<CVPasswordField> {
       ),
       child: TextFormField(
         focusNode: widget.focusNode,
-        maxLines: 1,
         obscureText: _obscureText,
         keyboardType: TextInputType.visiblePassword,
         style: TextStyle(

--- a/lib/ui/components/cv_social_card.dart
+++ b/lib/ui/components/cv_social_card.dart
@@ -29,7 +29,6 @@ class CircuitVerseSocialCard extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
           child: Row(
-            mainAxisAlignment: MainAxisAlignment.start,
             children: <Widget>[
               Image.asset(imagePath, width: 48),
               const SizedBox(width: 16),

--- a/lib/ui/components/cv_tab_bar.dart
+++ b/lib/ui/components/cv_tab_bar.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 
 class CVTabBar extends StatelessWidget implements PreferredSizeWidget {
   const CVTabBar({
-    Key? key,
-    this.color,
     required this.tabBar,
+    this.color,
+    Key? key,
   }) : super(key: key);
 
   final Color? color;

--- a/lib/ui/components/cv_typeahead_field.dart
+++ b/lib/ui/components/cv_typeahead_field.dart
@@ -11,6 +11,8 @@ class CVTypeAheadField extends StatelessWidget {
   /// When `maxLines` is not specified, it defaults to 1
   const CVTypeAheadField({
     required this.label,
+    required this.toggle,
+    required this.countryInstituteObject,
     this.type = TextInputType.text,
     this.action = TextInputAction.next,
     this.maxLines = 1,
@@ -22,9 +24,7 @@ class CVTypeAheadField extends StatelessWidget {
     ),
     this.focusNode,
     this.onFieldSubmitted,
-    required this.countryInstituteObject,
     this.controller,
-    required this.toggle,
     Key? key,
   }) : super(key: key);
 

--- a/lib/ui/views/authentication/forgot_password_view.dart
+++ b/lib/ui/views/authentication/forgot_password_view.dart
@@ -136,9 +136,7 @@ class _ForgotPasswordViewState extends State<ForgotPasswordView> {
                 const SizedBox(height: 8),
                 _buildNewUserSignUpComponent(),
                 const SizedBox(height: 32),
-                const AuthOptionsView(
-                  isSignUp: false,
-                ),
+                const AuthOptionsView(),
               ],
             ),
           ),

--- a/lib/ui/views/authentication/login_view.dart
+++ b/lib/ui/views/authentication/login_view.dart
@@ -163,7 +163,7 @@ class _LoginViewState extends State<LoginView> {
                 const SizedBox(height: 8),
                 _buildNewUserSignUpComponent(),
                 const SizedBox(height: 30),
-                const AuthOptionsView(isSignUp: false),
+                const AuthOptionsView(),
               ],
             ),
           ),

--- a/lib/ui/views/contributors/components/contributors_donate_card.dart
+++ b/lib/ui/views/contributors/components/contributors_donate_card.dart
@@ -3,10 +3,10 @@ import 'package:mobile_app/utils/url_launcher.dart';
 
 class ContributeDonateCard extends StatelessWidget {
   const ContributeDonateCard({
-    Key? key,
     required this.imagePath,
     required this.title,
     required this.url,
+    Key? key,
   }) : super(key: key);
 
   final String imagePath;
@@ -28,7 +28,7 @@ class ContributeDonateCard extends StatelessWidget {
           },
           child: Container(
             decoration: BoxDecoration(
-                border: Border.all(color: Colors.black, width: 2),
+                border: Border.all(width: 2),
                 borderRadius: const BorderRadius.all(
                   Radius.circular(8),
                 ),

--- a/lib/ui/views/contributors/components/contributors_support_card.dart
+++ b/lib/ui/views/contributors/components/contributors_support_card.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 
 class ContributeSupportCard extends StatelessWidget {
   const ContributeSupportCard({
-    Key? key,
     required this.imagePath,
     required this.title,
     required this.cardDescriptionList,
+    Key? key,
   }) : super(key: key);
 
   final String imagePath;

--- a/lib/ui/views/groups/add_assignment_view.dart
+++ b/lib/ui/views/groups/add_assignment_view.dart
@@ -16,7 +16,7 @@ import 'package:mobile_app/utils/validators.dart';
 import 'package:mobile_app/viewmodels/groups/add_assignment_viewmodel.dart';
 
 class AddAssignmentView extends StatefulWidget {
-  const AddAssignmentView({Key? key, required this.groupId}) : super(key: key);
+  const AddAssignmentView({required this.groupId, Key? key}) : super(key: key);
 
   static const String id = 'add_assignment_view';
   final String groupId;

--- a/lib/ui/views/groups/assignment_details_view.dart
+++ b/lib/ui/views/groups/assignment_details_view.dart
@@ -21,8 +21,8 @@ import 'package:transparent_image/transparent_image.dart';
 
 class AssignmentDetailsView extends StatefulWidget {
   const AssignmentDetailsView({
-    Key? key,
     required this.assignment,
+    Key? key,
   }) : super(key: key);
 
   static const String id = 'assignment_details_view';

--- a/lib/ui/views/groups/components/assignment_card.dart
+++ b/lib/ui/views/groups/components/assignment_card.dart
@@ -8,12 +8,12 @@ import 'package:mobile_app/ui/views/groups/components/group_card_button.dart';
 
 class AssignmentCard extends StatefulWidget {
   const AssignmentCard({
-    Key? key,
     required this.assignment,
     required this.onDeletePressed,
     required this.onEditPressed,
     required this.onReopenPressed,
     required this.onStartPressed,
+    Key? key,
   }) : super(key: key);
   final Assignment assignment;
   final VoidCallback onDeletePressed;
@@ -169,7 +169,6 @@ class _AssignmentCardState extends State<AssignmentCard> {
         color: CVTheme.boxBg(context),
       ),
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
           Text(
             widget.assignment.attributes.name ?? 'No Name',

--- a/lib/ui/views/groups/components/group_member_card.dart
+++ b/lib/ui/views/groups/components/group_member_card.dart
@@ -6,7 +6,7 @@ import 'package:mobile_app/ui/views/groups/components/group_card_button.dart';
 import 'package:mobile_app/ui/views/groups/group_details_view.dart';
 
 class GroupMemberCard extends StatelessWidget {
-  const GroupMemberCard({Key? key, required this.group}) : super(key: key);
+  const GroupMemberCard({required this.group, Key? key}) : super(key: key);
 
   final Group group;
 

--- a/lib/ui/views/groups/components/group_mentor_card.dart
+++ b/lib/ui/views/groups/components/group_mentor_card.dart
@@ -7,10 +7,10 @@ import 'package:mobile_app/ui/views/groups/group_details_view.dart';
 
 class GroupMentorCard extends StatefulWidget {
   const GroupMentorCard({
-    Key? key,
     required this.group,
     required this.onEdit,
     required this.onDelete,
+    Key? key,
   }) : super(key: key);
 
   final Group group;

--- a/lib/ui/views/groups/components/member_card.dart
+++ b/lib/ui/views/groups/components/member_card.dart
@@ -4,10 +4,10 @@ import 'package:mobile_app/models/group_members.dart';
 
 class MemberCard extends StatelessWidget {
   const MemberCard({
-    Key? key,
     required this.member,
-    this.hasMentorAccess = false,
     required this.onDeletePressed,
+    this.hasMentorAccess = false,
+    Key? key,
   }) : super(key: key);
 
   final GroupMember member;

--- a/lib/ui/views/groups/edit_group_view.dart
+++ b/lib/ui/views/groups/edit_group_view.dart
@@ -13,7 +13,7 @@ import 'package:mobile_app/utils/validators.dart';
 import 'package:mobile_app/viewmodels/groups/edit_group_viewmodel.dart';
 
 class EditGroupView extends StatefulWidget {
-  const EditGroupView({Key? key, required this.group}) : super(key: key);
+  const EditGroupView({required this.group, Key? key}) : super(key: key);
 
   static const String id = 'edit_group_view';
   final Group group;

--- a/lib/ui/views/groups/group_details_view.dart
+++ b/lib/ui/views/groups/group_details_view.dart
@@ -18,7 +18,7 @@ import 'package:mobile_app/ui/components/cv_flat_button.dart';
 import 'package:mobile_app/viewmodels/groups/group_details_viewmodel.dart';
 
 class GroupDetailsView extends StatefulWidget {
-  const GroupDetailsView({Key? key, required this.group}) : super(key: key);
+  const GroupDetailsView({required this.group, Key? key}) : super(key: key);
 
   static const String id = 'group_details_view';
   final Group group;

--- a/lib/ui/views/groups/my_groups_view.dart
+++ b/lib/ui/views/groups/my_groups_view.dart
@@ -38,7 +38,7 @@ class _MyGroupsViewState extends State<MyGroupsView>
           height: 250,
         ),
         _buildSubHeader(
-            title: "Explore and join groups of your school and friends!"),
+            title: 'Explore and join groups of your school and friends!'),
       ],
     );
   }
@@ -167,16 +167,18 @@ class _MyGroupsViewState extends State<MyGroupsView>
             return TabBarView(
               controller: _tabController,
               children: <Widget>[
-                _mentoredGroups.isEmpty
-                    ? _emptyState()
-                    : ListView(
-                        children: _mentoredGroups,
-                      ),
-                _joinedGroups.isEmpty
-                    ? _emptyState()
-                    : ListView(
-                        children: _joinedGroups,
-                      ),
+                if (_mentoredGroups.isEmpty)
+                  _emptyState()
+                else
+                  ListView(
+                    children: _mentoredGroups,
+                  ),
+                if (_joinedGroups.isEmpty)
+                  _emptyState()
+                else
+                  ListView(
+                    children: _joinedGroups,
+                  ),
               ],
             );
           },

--- a/lib/ui/views/groups/update_assignment_view.dart
+++ b/lib/ui/views/groups/update_assignment_view.dart
@@ -20,8 +20,8 @@ import 'package:mobile_app/viewmodels/groups/update_assignment_viewmodel.dart';
 
 class UpdateAssignmentView extends StatefulWidget {
   const UpdateAssignmentView({
-    Key? key,
     required this.assignment,
+    Key? key,
   }) : super(key: key);
 
   static const String id = 'update_assignment_view';

--- a/lib/ui/views/home/components/feature_card.dart
+++ b/lib/ui/views/home/components/feature_card.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 
 class FeatureCard extends StatelessWidget {
   const FeatureCard({
-    Key? key,
     required this.assetPath,
     required this.cardDescription,
     required this.cardHeading,
+    Key? key,
   }) : super(key: key);
 
   final String assetPath;

--- a/lib/ui/views/ib/components/ib_pop_quiz.dart
+++ b/lib/ui/views/ib/components/ib_pop_quiz.dart
@@ -6,9 +6,9 @@ import 'package:mobile_app/ui/views/ib/components/ib_pop_quiz_button.dart';
 
 class IbPopQuiz extends StatelessWidget {
   const IbPopQuiz({
-    Key? key,
     required this.context,
     required this.questions,
+    Key? key,
   }) : super(key: key);
 
   final BuildContext context;
@@ -55,7 +55,6 @@ class IbPopQuiz extends StatelessWidget {
     }
 
     return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(

--- a/lib/ui/views/ib/ib_landing_view.dart
+++ b/lib/ui/views/ib/ib_landing_view.dart
@@ -255,7 +255,7 @@ class _IbLandingViewState extends State<IbLandingView> {
                 final String key = globalKey
                     .toString()
                     .substring(1, globalKey.toString().length - 1)
-                    .split(" ")
+                    .split(' ')
                     .last;
                 model.onShowCased(key);
               },

--- a/lib/ui/views/ib/ib_page_view.dart
+++ b/lib/ui/views/ib/ib_page_view.dart
@@ -178,7 +178,6 @@ class _IbPageViewState extends State<IbPageView> {
 
     return MarkdownBody(
       data: data.content,
-      selectable: _selectable,
       imageDirectory: EnvironmentConfig.IB_BASE_URL,
       imageBuilder: _buildMarkdownImage,
       onTapLink: _onTapLink,

--- a/lib/ui/views/profile/profile_view.dart
+++ b/lib/ui/views/profile/profile_view.dart
@@ -122,7 +122,6 @@ class _ProfileViewState extends State<ProfileView> {
         child: Row(
           children: <Widget>[
             Expanded(
-              flex: 1,
               child: Column(
                 children: <Widget>[
                   _buildProfileImage(),

--- a/lib/ui/views/profile/user_projects_view.dart
+++ b/lib/ui/views/profile/user_projects_view.dart
@@ -8,8 +8,8 @@ import 'package:mobile_app/viewmodels/profile/user_projects_viewmodel.dart';
 
 class UserProjectsView extends StatefulWidget {
   const UserProjectsView({
-    Key? key,
     required this.userId,
+    Key? key,
   }) : super(key: key);
 
   final String userId;

--- a/lib/ui/views/projects/components/featured_project_card.dart
+++ b/lib/ui/views/projects/components/featured_project_card.dart
@@ -93,7 +93,6 @@ class _FeaturedProjectCardState extends State<FeaturedProjectCard> {
         elevation: 5,
         shadowColor: CVTheme.primaryColorLight,
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.start,
           children: <Widget>[
             _buildPreview(),
             _buildFooter(),

--- a/lib/ui/views/projects/components/project_card.dart
+++ b/lib/ui/views/projects/components/project_card.dart
@@ -6,10 +6,10 @@ import 'package:transparent_image/transparent_image.dart';
 
 class ProjectCard extends StatefulWidget {
   const ProjectCard({
-    Key? key,
     required this.project,
     required this.onPressed,
     this.isHeaderFilled = true,
+    Key? key,
   }) : super(key: key);
 
   final Project project;
@@ -112,7 +112,6 @@ class _ProjectCardState extends State<ProjectCard> {
           elevation: 5,
           shadowColor: CVTheme.primaryColorLight,
           child: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
             children: <Widget>[
               _buildHeader(),
               _buildPreview(),

--- a/lib/ui/views/projects/edit_project_view.dart
+++ b/lib/ui/views/projects/edit_project_view.dart
@@ -14,7 +14,7 @@ import 'package:mobile_app/utils/validators.dart';
 import 'package:mobile_app/viewmodels/projects/edit_project_viewmodel.dart';
 
 class EditProjectView extends StatefulWidget {
-  const EditProjectView({Key? key, required this.project}) : super(key: key);
+  const EditProjectView({required this.project, Key? key}) : super(key: key);
 
   static const String id = 'edit_project_view';
   final Project project;

--- a/lib/ui/views/projects/project_details_view.dart
+++ b/lib/ui/views/projects/project_details_view.dart
@@ -22,7 +22,7 @@ import 'package:share/share.dart';
 import 'package:transparent_image/transparent_image.dart';
 
 class ProjectDetailsView extends StatefulWidget {
-  const ProjectDetailsView({Key? key, required this.project}) : super(key: key);
+  const ProjectDetailsView({required this.project, Key? key}) : super(key: key);
 
   static const String id = 'project_details_view';
   final Project project;

--- a/lib/ui/views/projects/project_preview_fullscreen_view.dart
+++ b/lib/ui/views/projects/project_preview_fullscreen_view.dart
@@ -6,8 +6,8 @@ import 'package:transparent_image/transparent_image.dart';
 
 class ProjectPreviewFullScreen extends StatelessWidget {
   const ProjectPreviewFullScreen({
-    Key? key,
     required this.project,
+    Key? key,
   }) : super(key: key);
 
   static const String id = 'project_preview_fullscreen_view';

--- a/lib/ui/views/teachers/components/teachers_card.dart
+++ b/lib/ui/views/teachers/components/teachers_card.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 
 class TeachersCard extends StatelessWidget {
   const TeachersCard({
-    Key? key,
     required this.assetPath,
     required this.cardDescription,
     required this.cardHeading,
+    Key? key,
   }) : super(key: key);
 
   final String assetPath;

--- a/test/service_tests/contributors_api_test.dart
+++ b/test/service_tests/contributors_api_test.dart
@@ -27,7 +27,7 @@ void main() {
       test('When called & http client throws Exceptions', () async {
         var _contributorsApi = HttpContributorsApi();
 
-        ApiUtils.client = MockClient((_) => throw const FormatException(''));
+        ApiUtils.client = MockClient((_) => throw const FormatException());
         expect(_contributorsApi.fetchContributors(),
             throwsA(isInstanceOf<Failure>()));
 

--- a/test/service_tests/ib_api_test.dart
+++ b/test/service_tests/ib_api_test.dart
@@ -44,7 +44,7 @@ void main() {
 
         var _ibApi = HttpIbApi();
 
-        ApiUtils.client = MockClient((_) => throw const FormatException(''));
+        ApiUtils.client = MockClient((_) => throw const FormatException());
         expect(_ibApi.fetchApiPage(), throwsA(isInstanceOf<Failure>()));
 
         ApiUtils.client = MockClient((_) => throw Exception(''));
@@ -65,7 +65,7 @@ void main() {
       test('When called & http client throws Exceptions', () async {
         var _ibApi = HttpIbApi();
 
-        ApiUtils.client = MockClient((_) => throw const FormatException(''));
+        ApiUtils.client = MockClient((_) => throw const FormatException());
         expect(_ibApi.fetchRawPageData(), throwsA(isInstanceOf<Failure>()));
 
         ApiUtils.client = MockClient((_) => throw Exception(''));

--- a/test/service_tests/users_api_test.dart
+++ b/test/service_tests/users_api_test.dart
@@ -39,7 +39,7 @@ void main() {
         expect(_usersApi.login('test@test.com', 'test'),
             throwsA(isInstanceOf<Failure>()));
 
-        ApiUtils.client = MockClient((_) => throw const FormatException(''));
+        ApiUtils.client = MockClient((_) => throw const FormatException());
         expect(_usersApi.login('test@test.com', 'test'),
             throwsA(isInstanceOf<Failure>()));
 
@@ -66,7 +66,7 @@ void main() {
         expect(_usersApi.signup('test', 'test@test.com', 'test'),
             throwsA(isInstanceOf<Failure>()));
 
-        ApiUtils.client = MockClient((_) => throw const FormatException(''));
+        ApiUtils.client = MockClient((_) => throw const FormatException());
         expect(_usersApi.signup('test', 'test@test.com', 'test'),
             throwsA(isInstanceOf<Failure>()));
 
@@ -94,7 +94,7 @@ void main() {
         expect(_usersApi.oauthLogin(accessToken: 'token', provider: 'test'),
             throwsA(isInstanceOf<Failure>()));
 
-        ApiUtils.client = MockClient((_) => throw const FormatException(''));
+        ApiUtils.client = MockClient((_) => throw const FormatException());
         expect(_usersApi.oauthLogin(accessToken: 'token', provider: 'test'),
             throwsA(isInstanceOf<Failure>()));
 
@@ -122,7 +122,7 @@ void main() {
         expect(_usersApi.oauthSignup(accessToken: 'token', provider: 'test'),
             throwsA(isInstanceOf<Failure>()));
 
-        ApiUtils.client = MockClient((_) => throw const FormatException(''));
+        ApiUtils.client = MockClient((_) => throw const FormatException());
         expect(_usersApi.oauthSignup(accessToken: 'token', provider: 'test'),
             throwsA(isInstanceOf<Failure>()));
 
@@ -145,7 +145,7 @@ void main() {
       test('When called & http client throws Exceptions', () async {
         var _usersApi = HttpUsersApi();
 
-        ApiUtils.client = MockClient((_) => throw const FormatException(''));
+        ApiUtils.client = MockClient((_) => throw const FormatException());
         expect(_usersApi.fetchUser('1'), throwsA(isInstanceOf<Failure>()));
 
         ApiUtils.client = MockClient((_) => throw NotFoundException(''));
@@ -169,7 +169,7 @@ void main() {
       test('When called & http client throws Exceptions', () async {
         var _usersApi = HttpUsersApi();
 
-        ApiUtils.client = MockClient((_) => throw const FormatException(''));
+        ApiUtils.client = MockClient((_) => throw const FormatException());
         expect(_usersApi.fetchCurrentUser(), throwsA(isInstanceOf<Failure>()));
 
         ApiUtils.client = MockClient((_) => throw Exception(''));
@@ -197,7 +197,7 @@ void main() {
         when(_localStorage.currentUser).thenReturn(User.fromJson(mockUser));
         var _usersApi = HttpUsersApi();
 
-        ApiUtils.client = MockClient((_) => throw const FormatException(''));
+        ApiUtils.client = MockClient((_) => throw const FormatException());
         expect(_usersApi.updateProfile('Test User', 'Gurukul', 'India', true),
             throwsA(isInstanceOf<Failure>()));
 
@@ -224,7 +224,7 @@ void main() {
         expect(_usersApi.sendResetPasswordInstructions('test@test.com'),
             throwsA(isInstanceOf<Failure>()));
 
-        ApiUtils.client = MockClient((_) => throw const FormatException(''));
+        ApiUtils.client = MockClient((_) => throw const FormatException());
         expect(_usersApi.sendResetPasswordInstructions('test@test.com'),
             throwsA(isInstanceOf<Failure>()));
 

--- a/test/ui_tests/groups/my_groups_view_test.dart
+++ b/test/ui_tests/groups/my_groups_view_test.dart
@@ -79,7 +79,7 @@ void main() {
       expect(find.byType(FloatingActionButton), findsOneWidget);
 
       // Tap Joined Groups Tab
-      await tester.tap(find.widgetWithText(Tab, "Joined"));
+      await tester.tap(find.widgetWithText(Tab, 'Joined'));
       await tester.pumpAndSettle();
 
       // Member Group Card (1)
@@ -95,7 +95,7 @@ void main() {
       expect(find.widgetWithText(CardButton, 'View'), findsOneWidget);
 
       // Tap Mentored Groups Tab
-      await tester.tap(find.widgetWithText(Tab, "Mentored"));
+      await tester.tap(find.widgetWithText(Tab, 'Mentored'));
       await tester.pumpAndSettle();
 
       // Mentored Group Card (1)


### PR DESCRIPTION
Fixes #149 

Describe the changes you have made in this PR -
In the previous pull requests of this issue, linter rules are fixed and removed from `analysis_options.yaml`. They must be marked as true to enable them. 

Screenshots of the changes (If any) -

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.
