### PR TITLE
Fixes: #197 Added password validator for length of password in signup screen

### DIFF
--- a/lib/ui/views/authentication/signup_view.dart
+++ b/lib/ui/views/authentication/signup_view.dart
@@ -84,7 +84,7 @@ class _SignupViewState extends State<SignupView> {
       focusNode: _emailFocusNode,
       validator: (value) {
         if (value!.isEmpty) {
-          return "Password can\'t be empty";
+          return "Password can't be empty";
         } else if (value.length < 6) {
           return "Password length should be at least 6";
         }

--- a/lib/ui/views/authentication/signup_view.dart
+++ b/lib/ui/views/authentication/signup_view.dart
@@ -82,8 +82,14 @@ class _SignupViewState extends State<SignupView> {
   Widget _buildPasswordInput() {
     return CVPasswordField(
       focusNode: _emailFocusNode,
-      validator: (value) =>
-          value?.isEmpty ?? true ? 'Password can\'t be empty' : null,
+      validator: (value) {
+        if (value!.isEmpty) {
+          return "Password cannot be empty";
+        } else if (value.length < 6) {
+          return "Password length should be at least 6";
+        }
+        return null;
+      },
       onSaved: (value) => _password = value!.trim(),
     );
   }

--- a/lib/ui/views/authentication/signup_view.dart
+++ b/lib/ui/views/authentication/signup_view.dart
@@ -84,7 +84,7 @@ class _SignupViewState extends State<SignupView> {
       focusNode: _emailFocusNode,
       validator: (value) {
         if (value!.isEmpty) {
-          return "Password cannot be empty";
+          return "Password can\'t be empty";
         } else if (value.length < 6) {
           return "Password length should be at least 6";
         }

--- a/test/ui_tests/authentication/signup_view_test.dart
+++ b/test/ui_tests/authentication/signup_view_test.dart
@@ -99,10 +99,8 @@ void main() {
       verifyNever(_usersApiMock.signup('test', 'test@test.com', ''));
       expect(find.text('Password can\'t be empty'), findsOneWidget);
 
-
       await tester.enterText(
-          find.byWidgetPredicate((Widget widget) =>
-              widget is CVPasswordField ),
+          find.byWidgetPredicate((Widget widget) => widget is CVPasswordField),
           'abcd');
       await tester.tap(find.byType(CVPrimaryButton));
       await tester.pumpAndSettle();

--- a/test/ui_tests/authentication/signup_view_test.dart
+++ b/test/ui_tests/authentication/signup_view_test.dart
@@ -98,6 +98,17 @@ void main() {
 
       verifyNever(_usersApiMock.signup('test', 'test@test.com', ''));
       expect(find.text('Password can\'t be empty'), findsOneWidget);
+
+
+      await tester.enterText(
+          find.byWidgetPredicate((Widget widget) =>
+              widget is CVPasswordField ),
+          'abcd');
+      await tester.tap(find.byType(CVPrimaryButton));
+      await tester.pumpAndSettle();
+
+      verifyNever(_usersApiMock.signup('test', 'test@test.com', 'abcd'));
+      expect(find.text('Password length should be at least 6'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Fixes #197 

Describe the changes you have made in this PR -
Added password validator for length of password  in signup screen. Earlier it was not there.

Screenshots of the changes (If any) -
<img src="https://user-images.githubusercontent.com/54404474/151703465-34bff102-5690-4d22-93e5-98de16ce6fe3.png" height="550" width="250" />


Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.
