### PR TITLE
fix(favorites): updated starred state is not reflecting

### DIFF
--- a/lib/models/projects.dart
+++ b/lib/models/projects.dart
@@ -46,6 +46,22 @@ class Project {
   ProjectRelationships relationships;
   List<Collaborator>? collaborators;
 
+  Project copyWith({
+    String? id,
+    String? type,
+    ProjectAttributes? attributes,
+    ProjectRelationships? relationships,
+    List<Collaborator>? collaborators,
+  }) {
+    return Project(
+      id: id ?? this.id,
+      type: type ?? this.type,
+      attributes: attributes ?? this.attributes,
+      relationships: relationships ?? this.relationships,
+      collaborators: collaborators ?? this.collaborators,
+    );
+  }
+
   bool get hasAuthorAccess {
     var currentUser = locator<LocalStorageService>().currentUser;
 
@@ -81,7 +97,7 @@ class ProjectAttributes {
     this.description,
     required this.view,
     required this.tags,
-    this.isStarred,
+    required this.isStarred,
     required this.authorName,
     required this.starsCount,
   });
@@ -94,9 +110,37 @@ class ProjectAttributes {
   String? description;
   int view;
   List<Tag> tags;
-  bool? isStarred;
+  bool isStarred;
   String authorName;
   int starsCount;
+
+  ProjectAttributes copyWith({
+    String? name,
+    String? projectAccessType,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    ImagePreview? imagePreview,
+    String? description,
+    int? view,
+    List<Tag>? tags,
+    bool? isStarred,
+    String? authorName,
+    int? starsCount,
+  }) {
+    return ProjectAttributes(
+      name: name ?? this.name,
+      projectAccessType: projectAccessType ?? this.projectAccessType,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      imagePreview: imagePreview ?? this.imagePreview,
+      view: view ?? this.view,
+      tags: tags ?? this.tags,
+      authorName: authorName ?? this.authorName,
+      starsCount: starsCount ?? this.starsCount,
+      description: description ?? this.description,
+      isStarred: isStarred ?? this.isStarred,
+    );
+  }
 }
 
 class ImagePreview {

--- a/lib/ui/views/profile/user_favourites_view.dart
+++ b/lib/ui/views/profile/user_favourites_view.dart
@@ -5,7 +5,9 @@ import 'package:mobile_app/ui/components/cv_add_icon_button.dart';
 import 'package:mobile_app/ui/views/base_view.dart';
 import 'package:mobile_app/ui/views/projects/components/project_card.dart';
 import 'package:mobile_app/ui/views/projects/project_details_view.dart';
+import 'package:mobile_app/viewmodels/profile/profile_viewmodel.dart';
 import 'package:mobile_app/viewmodels/profile/user_favourites_viewmodel.dart';
+import 'package:provider/provider.dart';
 
 class UserFavouritesView extends StatefulWidget {
   const UserFavouritesView({
@@ -30,7 +32,14 @@ class _UserFavouritesViewState extends State<UserFavouritesView>
   Widget build(BuildContext context) {
     super.build(context);
     return BaseView<UserFavouritesViewModel>(
-      onModelReady: (model) => model.fetchUserFavourites(userId: widget.userId),
+      onModelReady: (model) {
+        model.fetchUserFavourites(userId: widget.userId);
+        context.watch<ProfileViewModel>().addListener(() {
+          final project = context.read<ProfileViewModel>().updatedProject;
+          if (project == null) return;
+          model.onProjectChanged(project);
+        });
+      },
       builder: (context, model, child) {
         final _items = <Widget>[];
 
@@ -44,7 +53,10 @@ class _UserFavouritesViewState extends State<UserFavouritesView>
                   var _result = await Get.toNamed(ProjectDetailsView.id,
                       arguments: project);
                   if (_result is bool) model.onProjectDeleted(project.id);
-                  if (_result is Project) model.onProjectUnstarred(project.id);
+                  if (_result is Project) {
+                    model.onProjectChanged(_result);
+                    context.read<ProfileViewModel>().updatedProject = _result;
+                  }
                 },
               ),
             );

--- a/lib/ui/views/profile/user_favourites_view.dart
+++ b/lib/ui/views/profile/user_favourites_view.dart
@@ -44,6 +44,7 @@ class _UserFavouritesViewState extends State<UserFavouritesView>
                   var _result = await Get.toNamed(ProjectDetailsView.id,
                       arguments: project);
                   if (_result is bool) model.onProjectDeleted(project.id);
+                  if (_result is Project) model.onProjectUnstarred(project.id);
                 },
               ),
             );

--- a/lib/ui/views/projects/featured_projects_view.dart
+++ b/lib/ui/views/projects/featured_projects_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:mobile_app/models/projects.dart';
 import 'package:mobile_app/ui/components/cv_header.dart';
 import 'package:mobile_app/ui/components/cv_primary_button.dart';
 import 'package:mobile_app/ui/views/base_view.dart';
@@ -38,7 +39,14 @@ class _FeaturedProjectsViewState extends State<FeaturedProjectsView> {
               FeaturedProjectCard(
                 project: project,
                 onViewPressed: () async {
-                  await Get.toNamed(ProjectDetailsView.id, arguments: project);
+                  final _result = await Get.toNamed(
+                    ProjectDetailsView.id,
+                    arguments: project,
+                  );
+
+                  if (_result is Project) {
+                    model.updateFeaturedProject(_result);
+                  }
                 },
               ),
             );

--- a/lib/ui/views/projects/project_details_view.dart
+++ b/lib/ui/views/projects/project_details_view.dart
@@ -574,7 +574,7 @@ class _ProjectDetailsViewState extends State<ProjectDetailsView> {
       builder: (context, model, child) => WillPopScope(
         onWillPop: () async {
           // Check whether the state (i.e starred or not) is changed
-          final bool isChanged = model.receivedProject.attributes.isStarred ^
+          final bool isChanged = model.receivedProject!.attributes.isStarred ^
               _recievedProject.attributes.isStarred;
           Get.back(
             result: isChanged ? model.receivedProject : null,

--- a/lib/ui/views/projects/project_details_view.dart
+++ b/lib/ui/views/projects/project_details_view.dart
@@ -8,7 +8,6 @@ import 'package:mobile_app/locator.dart';
 import 'package:mobile_app/models/collaborators.dart';
 import 'package:mobile_app/models/projects.dart';
 import 'package:mobile_app/services/dialog_service.dart';
-import 'package:mobile_app/services/local_storage_service.dart';
 import 'package:mobile_app/ui/components/cv_flat_button.dart';
 import 'package:mobile_app/ui/views/base_view.dart';
 import 'package:mobile_app/ui/views/profile/profile_view.dart';
@@ -32,8 +31,6 @@ class ProjectDetailsView extends StatefulWidget {
 }
 
 class _ProjectDetailsViewState extends State<ProjectDetailsView> {
-  final LocalStorageService _localStorageService =
-      locator<LocalStorageService>();
   final DialogService _dialogService = locator<DialogService>();
   late ProjectDetailsViewModel _model;
   final _formKey = GlobalKey<FormState>();
@@ -566,92 +563,105 @@ class _ProjectDetailsViewState extends State<ProjectDetailsView> {
     return BaseView<ProjectDetailsViewModel>(
       onModelReady: (model) {
         _model = model;
+        _model.receivedProject = _recievedProject;
         // initialize collaborators & isStarred for the project..
         _model.collaborators = _recievedProject.collaborators;
-        _model.isProjectStarred =
-            _recievedProject.attributes.isStarred ?? false;
+        _model.isProjectStarred = _recievedProject.attributes.isStarred;
         _model.starCount = _recievedProject.attributes.starsCount;
 
         _model.fetchProjectDetails(_recievedProject.id);
       },
-      builder: (context, model, child) => Scaffold(
-        appBar: AppBar(
-          title: const Text('Project Details'),
-          actions: [
-            _buildShareActionButton(),
-          ],
-        ),
-        body: Builder(builder: (context) {
-          var _projectAttrs = _recievedProject.attributes;
-          var _items = <Widget>[];
+      builder: (context, model, child) => WillPopScope(
+        onWillPop: () async {
+          // Check whether the state (i.e starred or not) is changed
+          final bool isChanged = model.receivedProject.attributes.isStarred ^
+              _recievedProject.attributes.isStarred;
+          Get.back(
+            result: isChanged ? model.receivedProject : null,
+          );
+          return false;
+        },
+        child: Scaffold(
+          appBar: AppBar(
+            title: const Text('Project Details'),
+            actions: [
+              _buildShareActionButton(),
+            ],
+          ),
+          body: Builder(
+            builder: (context) {
+              var _projectAttrs = _recievedProject.attributes;
+              var _items = <Widget>[];
 
-          // Adds project preview..
-          _items.add(_buildProjectPreview());
+              // Adds project preview..
+              _items.add(_buildProjectPreview());
 
-          _items.add(const SizedBox(height: 16));
+              _items.add(const SizedBox(height: 16));
 
-          // Adds Project Name, Star & View count..
-          _items.add(_buildProjectNameHeader());
+              // Adds Project Name, Star & View count..
+              _items.add(_buildProjectNameHeader());
 
-          // Adds Project attributes..
-          _items.add(
-            Container(
-              padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 8),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  _buildProjectAuthor(),
-                  _buildProjectDetailComponent(
-                    'Project Access Type',
-                    _projectAttrs.projectAccessType,
-                  ),
-                  _buildProjectDescription(),
-                  const Divider(height: 32),
-                  Wrap(
-                    spacing: 8,
-                    crossAxisAlignment: WrapCrossAlignment.center,
+              // Adds Project attributes..
+              _items.add(
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(vertical: 16, horizontal: 8),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
-                      if (!_recievedProject.hasAuthorAccess &&
-                          _localStorageService.isLoggedIn)
-                        _buildForkProjectButton(),
-                      if (_localStorageService.isLoggedIn)
-                        _buildStarProjectButton(),
+                      _buildProjectAuthor(),
+                      _buildProjectDetailComponent(
+                        'Project Access Type',
+                        _projectAttrs.projectAccessType,
+                      ),
+                      _buildProjectDescription(),
+                      const Divider(height: 32),
+                      Wrap(
+                        spacing: 8,
+                        crossAxisAlignment: WrapCrossAlignment.center,
+                        children: <Widget>[
+                          if (!_recievedProject.hasAuthorAccess &&
+                              model.isLoggedIn)
+                            _buildForkProjectButton(),
+                          if (model.isLoggedIn) _buildStarProjectButton(),
+                          if (_recievedProject.hasAuthorAccess)
+                            _buildAddCollaboratorsButton(),
+                        ],
+                      ),
+                      const Divider(height: 32),
                       if (_recievedProject.hasAuthorAccess)
-                        _buildAddCollaboratorsButton(),
+                        Wrap(
+                          spacing: 8,
+                          children: <Widget>[
+                            _buildEditButton(),
+                            _buildDeleteButton(),
+                          ],
+                        ),
                     ],
                   ),
-                  const Divider(height: 32),
-                  if (_recievedProject.hasAuthorAccess)
-                    Wrap(
-                      spacing: 8,
-                      children: <Widget>[
-                        _buildEditButton(),
-                        _buildDeleteButton(),
-                      ],
-                    ),
-                ],
-              ),
-            ),
-          );
-
-          if (_model.isSuccess(_model.FETCH_PROJECT_DETAILS) &&
-              _model.collaborators.isNotEmpty) {
-            _items.add(const Divider());
-
-            _items.add(_buildProjectHeader('Collaborators'));
-
-            for (var collaborator in _model.collaborators) {
-              _items.add(
-                _buildCollaborator(collaborator),
+                ),
               );
-            }
-          }
-          return ListView(
-            shrinkWrap: true,
-            padding: const EdgeInsets.all(16),
-            children: _items,
-          );
-        }),
+
+              if (_model.isSuccess(_model.FETCH_PROJECT_DETAILS) &&
+                  _model.collaborators.isNotEmpty) {
+                _items.add(const Divider());
+
+                _items.add(_buildProjectHeader('Collaborators'));
+
+                for (var collaborator in _model.collaborators) {
+                  _items.add(
+                    _buildCollaborator(collaborator),
+                  );
+                }
+              }
+              return ListView(
+                shrinkWrap: true,
+                padding: const EdgeInsets.all(16),
+                children: _items,
+              );
+            },
+          ),
+        ),
       ),
     );
   }

--- a/lib/viewmodels/profile/profile_viewmodel.dart
+++ b/lib/viewmodels/profile/profile_viewmodel.dart
@@ -1,6 +1,7 @@
 import 'package:mobile_app/enums/view_state.dart';
 import 'package:mobile_app/locator.dart';
 import 'package:mobile_app/models/failure_model.dart';
+import 'package:mobile_app/models/projects.dart';
 import 'package:mobile_app/models/user.dart';
 import 'package:mobile_app/services/API/users_api.dart';
 import 'package:mobile_app/viewmodels/base_viewmodel.dart';
@@ -17,6 +18,15 @@ class ProfileViewModel extends BaseModel {
 
   set user(User? user) {
     _user = user;
+    notifyListeners();
+  }
+
+  Project? _updatedProject;
+
+  Project? get updatedProject => _updatedProject;
+
+  set updatedProject(Project? project) {
+    _updatedProject = project;
     notifyListeners();
   }
 

--- a/lib/viewmodels/profile/user_favourites_viewmodel.dart
+++ b/lib/viewmodels/profile/user_favourites_viewmodel.dart
@@ -36,8 +36,17 @@ class UserFavouritesViewModel extends BaseModel {
     _removeFromUserFavorites(projectId);
   }
 
-  void onProjectUnstarred(String projectId) {
-    _removeFromUserFavorites(projectId);
+  void _addToUserFavorites(Project project) {
+    _userFavourites.add(project);
+    notifyListeners();
+  }
+
+  void onProjectChanged(Project project) {
+    if (project.attributes.isStarred) {
+      _addToUserFavorites(project);
+    } else {
+      _removeFromUserFavorites(project.id);
+    }
   }
 
   Future? fetchUserFavourites({String? userId}) async {

--- a/lib/viewmodels/profile/user_favourites_viewmodel.dart
+++ b/lib/viewmodels/profile/user_favourites_viewmodel.dart
@@ -27,9 +27,17 @@ class UserFavouritesViewModel extends BaseModel {
     notifyListeners();
   }
 
-  void onProjectDeleted(String projectId) {
+  void _removeFromUserFavorites(String projectId) {
     _userFavourites.removeWhere((_project) => _project.id == projectId);
     notifyListeners();
+  }
+
+  void onProjectDeleted(String projectId) {
+    _removeFromUserFavorites(projectId);
+  }
+
+  void onProjectUnstarred(String projectId) {
+    _removeFromUserFavorites(projectId);
   }
 
   Future? fetchUserFavourites({String? userId}) async {

--- a/lib/viewmodels/profile/user_projects_viewmodel.dart
+++ b/lib/viewmodels/profile/user_projects_viewmodel.dart
@@ -27,6 +27,15 @@ class UserProjectsViewModel extends BaseModel {
     notifyListeners();
   }
 
+  void onProjectChanged(Project project) {
+    final int index = _userProjects.indexWhere(
+      (element) => element.id == project.id,
+    );
+    if (index == -1) return;
+    _userProjects[index] = project;
+    notifyListeners();
+  }
+
   void onProjectDeleted(String projectId) {
     _userProjects.removeWhere((_project) => _project.id == projectId);
     notifyListeners();

--- a/lib/viewmodels/projects/featured_projects_viewmodel.dart
+++ b/lib/viewmodels/projects/featured_projects_viewmodel.dart
@@ -24,6 +24,14 @@ class FeaturedProjectsViewModel extends BaseModel {
     notifyListeners();
   }
 
+  void updateFeaturedProject(Project project) {
+    final int index = _featuredProjects.indexWhere(
+      (element) => element.id == project.id,
+    );
+    _featuredProjects[index] = project;
+    notifyListeners();
+  }
+
   Future? fetchFeaturedProjects({int size = 5}) async {
     try {
       if (previousFeaturedProjectsBatch?.links.next != null) {

--- a/lib/viewmodels/projects/project_details_viewmodel.dart
+++ b/lib/viewmodels/projects/project_details_viewmodel.dart
@@ -24,7 +24,7 @@ class ProjectDetailsViewModel extends BaseModel {
 
   bool get isLoggedIn => _localStorageService.isLoggedIn;
 
-  late Project receivedProject;
+  Project? receivedProject;
 
   Project? _project;
 
@@ -171,8 +171,8 @@ class ProjectDetailsViewModel extends BaseModel {
       isProjectStarred = _toggleMessage!.contains('Starred') ? true : false;
       isProjectStarred ? starCount++ : starCount--;
 
-      receivedProject = receivedProject.copyWith(
-        attributes: receivedProject.attributes.copyWith(
+      receivedProject = receivedProject!.copyWith(
+        attributes: receivedProject!.attributes.copyWith(
           isStarred: isProjectStarred,
           starsCount: starCount,
         ),

--- a/lib/viewmodels/projects/project_details_viewmodel.dart
+++ b/lib/viewmodels/projects/project_details_viewmodel.dart
@@ -5,6 +5,7 @@ import 'package:mobile_app/models/failure_model.dart';
 import 'package:mobile_app/models/projects.dart';
 import 'package:mobile_app/services/API/collaborators_api.dart';
 import 'package:mobile_app/services/API/projects_api.dart';
+import 'package:mobile_app/services/local_storage_service.dart';
 import 'package:mobile_app/viewmodels/base_viewmodel.dart';
 
 class ProjectDetailsViewModel extends BaseModel {
@@ -18,6 +19,12 @@ class ProjectDetailsViewModel extends BaseModel {
 
   final ProjectsApi _projectsApi = locator<ProjectsApi>();
   final CollaboratorsApi _collaboratorsApi = locator<CollaboratorsApi>();
+  final LocalStorageService _localStorageService =
+      locator<LocalStorageService>();
+
+  bool get isLoggedIn => _localStorageService.isLoggedIn;
+
+  late Project receivedProject;
 
   Project? _project;
 
@@ -163,6 +170,13 @@ class ProjectDetailsViewModel extends BaseModel {
       var _toggleMessage = await _projectsApi.toggleStarProject(projectId);
       isProjectStarred = _toggleMessage!.contains('Starred') ? true : false;
       isProjectStarred ? starCount++ : starCount--;
+
+      receivedProject = receivedProject.copyWith(
+        attributes: receivedProject.attributes.copyWith(
+          isStarred: isProjectStarred,
+          starsCount: starCount,
+        ),
+      );
 
       setStateFor(TOGGLE_STAR, ViewState.Success);
     } on Failure catch (f) {

--- a/test/ui_tests/profile/user_favourites_view_test.dart
+++ b/test/ui_tests/profile/user_favourites_view_test.dart
@@ -81,6 +81,12 @@ void main() {
         locator.registerSingleton<ProjectDetailsViewModel>(
             projectDetailsViewModel);
 
+        final _recievedProject = Project.fromJson(mockProject);
+        when(projectDetailsViewModel.receivedProject)
+            .thenAnswer((_) => _recievedProject);
+        when(projectDetailsViewModel.isLoggedIn).thenAnswer((_) => true);
+        when(projectDetailsViewModel.isProjectStarred)
+            .thenAnswer((_) => _recievedProject.attributes.isStarred);
         when(projectDetailsViewModel.starCount).thenAnswer((_) => 0);
         when(projectDetailsViewModel.FETCH_PROJECT_DETAILS)
             .thenAnswer((_) => 'fetch_project_details');

--- a/test/ui_tests/profile/user_favourites_view_test.dart
+++ b/test/ui_tests/profile/user_favourites_view_test.dart
@@ -3,9 +3,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/locator.dart';
 import 'package:mobile_app/models/projects.dart';
+import 'package:mobile_app/ui/views/base_view.dart';
 import 'package:mobile_app/ui/views/profile/user_favourites_view.dart';
 import 'package:mobile_app/ui/views/projects/components/project_card.dart';
 import 'package:mobile_app/ui/views/projects/project_details_view.dart';
+import 'package:mobile_app/viewmodels/profile/profile_viewmodel.dart';
 import '../../setup/test_helpers.mocks.dart';
 import '../../utils_tests/image_test_utils.dart';
 import 'package:mobile_app/utils/router.dart';
@@ -29,6 +31,10 @@ void main() {
     setUp(() => mockObserver = MockNavigatorObserver());
 
     Future<void> _pumpUserFavouritesView(WidgetTester tester) async {
+      // Mock User Profile ViewModel
+      final _profileViewModel = MockProfileViewModel();
+      locator.registerSingleton<ProfileViewModel>(_profileViewModel);
+
       // Mock User Favorites ViewModel
       var _userFavoritesViewModel = MockUserFavouritesViewModel();
       locator
@@ -49,8 +55,12 @@ void main() {
         GetMaterialApp(
           onGenerateRoute: CVRouter.generateRoute,
           navigatorObservers: [mockObserver],
-          home: const Scaffold(
-            body: UserFavouritesView(),
+          home: BaseView<ProfileViewModel>(
+            builder: (context, model, child) {
+              return const Scaffold(
+                body: UserFavouritesView(),
+              );
+            },
           ),
         ),
       );

--- a/test/ui_tests/profile/user_projects_view_test.dart
+++ b/test/ui_tests/profile/user_projects_view_test.dart
@@ -83,6 +83,12 @@ void main() {
         locator.registerSingleton<ProjectDetailsViewModel>(
             projectDetailsViewModel);
 
+        final _recievedProject = Project.fromJson(mockProject);
+        when(projectDetailsViewModel.receivedProject)
+            .thenAnswer((_) => _recievedProject);
+        when(projectDetailsViewModel.isLoggedIn).thenAnswer((_) => true);
+        when(projectDetailsViewModel.isProjectStarred)
+            .thenAnswer((_) => _recievedProject.attributes.isStarred);
         when(projectDetailsViewModel.starCount).thenAnswer((_) => 0);
         when(projectDetailsViewModel.FETCH_PROJECT_DETAILS)
             .thenAnswer((_) => 'fetch_project_details');

--- a/test/ui_tests/profile/user_projects_view_test.dart
+++ b/test/ui_tests/profile/user_projects_view_test.dart
@@ -3,9 +3,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/locator.dart';
 import 'package:mobile_app/models/projects.dart';
+import 'package:mobile_app/ui/views/base_view.dart';
 import 'package:mobile_app/ui/views/profile/user_projects_view.dart';
 import 'package:mobile_app/ui/views/projects/components/project_card.dart';
 import 'package:mobile_app/ui/views/projects/project_details_view.dart';
+import 'package:mobile_app/viewmodels/profile/profile_viewmodel.dart';
 import '../../setup/test_helpers.mocks.dart';
 import '../../utils_tests/image_test_utils.dart';
 import 'package:mobile_app/utils/router.dart';
@@ -29,6 +31,10 @@ void main() {
     setUp(() => mockObserver = MockNavigatorObserver());
 
     Future<void> _pumpUserProjectsView(WidgetTester tester) async {
+      // Mock User Profile ViewModel
+      final _profileViewModel = MockProfileViewModel();
+      locator.registerSingleton<ProfileViewModel>(_profileViewModel);
+
       // Mock User Projects ViewModel
       var _userProjectsViewModel = MockUserProjectsViewModel();
       locator.registerSingleton<UserProjectsViewModel>(_userProjectsViewModel);
@@ -49,10 +55,14 @@ void main() {
         GetMaterialApp(
           onGenerateRoute: CVRouter.generateRoute,
           navigatorObservers: [mockObserver],
-          home: const Scaffold(
-            body: UserProjectsView(
-              userId: 'user_id',
-            ),
+          home: BaseView<ProfileViewModel>(
+            builder: (context, model, child) {
+              return const Scaffold(
+                body: UserProjectsView(
+                  userId: 'user_id',
+                ),
+              );
+            },
           ),
         ),
       );

--- a/test/ui_tests/projects/featured_projects_view_test.dart
+++ b/test/ui_tests/projects/featured_projects_view_test.dart
@@ -83,6 +83,12 @@ void main() {
         locator.registerSingleton<ProjectDetailsViewModel>(
             projectDetailsViewModel);
 
+        final _recievedProject = Project.fromJson(mockProject);
+        when(projectDetailsViewModel.receivedProject)
+            .thenAnswer((_) => _recievedProject);
+        when(projectDetailsViewModel.isLoggedIn).thenAnswer((_) => true);
+        when(projectDetailsViewModel.isProjectStarred)
+            .thenAnswer((_) => _recievedProject.attributes.isStarred);
         when(projectDetailsViewModel.starCount).thenAnswer((_) => 0);
         when(projectDetailsViewModel.FETCH_PROJECT_DETAILS)
             .thenAnswer((_) => 'fetch_project_details');

--- a/test/viewmodel_tests/projects/project_details_viewmodel_test.dart
+++ b/test/viewmodel_tests/projects/project_details_viewmodel_test.dart
@@ -176,6 +176,7 @@ void main() {
             .thenAnswer((_) => Future.value('Starred'));
 
         var _model = ProjectDetailsViewModel();
+        _model.receivedProject = Project.fromJson(mockProject);
         await _model.toggleStarForProject('1');
 
         // verify API call is made..
@@ -192,6 +193,7 @@ void main() {
             .thenAnswer((_) => Future.value('Unstarred'));
 
         var _model = ProjectDetailsViewModel();
+        _model.receivedProject = Project.fromJson(mockProject);
         await _model.toggleStarForProject('1');
 
         // verify API call is made..


### PR DESCRIPTION
Fixes #70 

Describe the changes you have made in this PR - The changed of state of starred is not reflected after the screen is popped. For example, in featured circuits if user starred a project then move back and again returning to that project still shows the previous state i.e. unstarred and similar thing in profile favorites section, if user unstarred the project then it is not removed from there.

Screenshots of the changes (If any) -

https://user-images.githubusercontent.com/77198905/152423214-1ed2838f-43ab-4dd2-a417-bce211d99105.mp4



Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.
