### PR TITLE
bfix(markdown)!: fix inline html parsing

### DIFF
--- a/lib/services/ib_engine_service.dart
+++ b/lib/services/ib_engine_service.dart
@@ -249,31 +249,12 @@ class IbEngineServiceImpl implements IbEngineService {
 
     if (_ibRawPageData == null) return null;
 
-    /// Inline HTML Tags bounded by Backticks(`) are not parsed
-    /// For example,
-    ///   2<sup>6</sup> -> 2^6
-    ///   whereas, `2<sup>6</sup>` -> `2<sup>6</sup>`
-    final content = HtmlUnescape()
-        .convert(_ibRawPageData.rawContent)
-        .splitMapJoin(
-          RegExp(r'\`(.*?)\`'),
-          onMatch: (m) {
-            if (m[1] != null &&
-                RegExp(r'<(\S*?)[^>]*>(.*?)<\/\1>|<.*?\/>').hasMatch(m[1]!)) {
-              return '${m[1]}';
-            }
-
-            return '${m[0]}';
-          },
-          onNonMatch: (n) => n,
-        );
-
     return IbPageData(
       id: _ibRawPageData.id,
       pageUrl: _ibRawPageData.httpUrl,
       title: _ibRawPageData.title,
       content: [
-        IbMd(content: '$content\n'),
+        IbMd(content: '${HtmlUnescape().convert(_ibRawPageData.rawContent)}\n'),
       ],
       tableOfContents: _ibRawPageData.hasToc
           ? _getTableOfContents(_ibRawPageData.content!)

--- a/lib/services/ib_engine_service.dart
+++ b/lib/services/ib_engine_service.dart
@@ -249,12 +249,31 @@ class IbEngineServiceImpl implements IbEngineService {
 
     if (_ibRawPageData == null) return null;
 
+    /// Inline HTML Tags bounded by Backticks(`) are not parsed
+    /// For example,
+    ///   2<sup>6</sup> -> 2^6
+    ///   whereas, `2<sup>6</sup>` -> `2<sup>6</sup>`
+    final content = HtmlUnescape()
+        .convert(_ibRawPageData.rawContent)
+        .splitMapJoin(
+          RegExp(r'\`(.*?)\`'),
+          onMatch: (m) {
+            if (m[1] != null &&
+                RegExp(r'<(\S*?)[^>]*>(.*?)<\/\1>|<.*?\/>').hasMatch(m[1]!)) {
+              return '${m[1]}';
+            }
+
+            return '${m[0]}';
+          },
+          onNonMatch: (n) => n,
+        );
+
     return IbPageData(
       id: _ibRawPageData.id,
       pageUrl: _ibRawPageData.httpUrl,
       title: _ibRawPageData.title,
       content: [
-        IbMd(content: '${HtmlUnescape().convert(_ibRawPageData.rawContent)}\n'),
+        IbMd(content: '$content\n'),
       ],
       tableOfContents: _ibRawPageData.hasToc
           ? _getTableOfContents(_ibRawPageData.content!)

--- a/lib/ui/views/ib/ib_page_view.dart
+++ b/lib/ui/views/ib/ib_page_view.dart
@@ -19,6 +19,7 @@ import 'package:mobile_app/ui/views/ib/builders/ib_pop_quiz_builder.dart';
 import 'package:mobile_app/ui/views/ib/builders/ib_subscript_builder.dart';
 import 'package:mobile_app/ui/views/ib/builders/ib_superscript_builder.dart';
 import 'package:mobile_app/ui/views/ib/builders/ib_webview_builder.dart';
+import 'package:mobile_app/ui/views/ib/syntaxes/ib_backticks_syntax.dart';
 import 'package:mobile_app/ui/views/ib/syntaxes/ib_embed_syntax.dart';
 import 'package:mobile_app/ui/views/ib/syntaxes/ib_filter_syntax.dart';
 import 'package:mobile_app/ui/views/ib/syntaxes/ib_inline_html_syntax.dart';
@@ -214,6 +215,7 @@ class _IbPageViewState extends State<IbPageView> {
         [
           IbInlineHtmlSyntax(builders: _inlineBuilders),
           IbMathjaxSyntax(),
+          IbBackTicksSyntax(),
           md.EmojiSyntax(),
           ...md.ExtensionSet.gitHubFlavored.inlineSyntaxes,
         ],

--- a/lib/ui/views/ib/syntaxes/ib_backticks_syntax.dart
+++ b/lib/ui/views/ib/syntaxes/ib_backticks_syntax.dart
@@ -1,0 +1,38 @@
+import 'package:markdown/markdown.dart' as md;
+import 'package:mobile_app/ui/views/ib/syntaxes/ib_inline_html_syntax.dart';
+
+class IbBackTicksSyntax extends md.InlineSyntax {
+  IbBackTicksSyntax() : super(_pattern);
+
+  static const String _pattern = r'\`(.*?)\`';
+
+  @override
+  bool onMatch(md.InlineParser parser, Match match) {
+    final String matched = match[1] ?? '';
+
+    final inlineRegex = RegExp(IbInlineHtmlSyntax.Pattern);
+
+    /// Inline HTML Tags bounded by Backticks(`) are not parsed
+    if (inlineRegex.hasMatch(matched)) {
+      for (var word in matched.split(' ')) {
+        if (inlineRegex.hasMatch(word)) {
+          parser.addNode(md.Text(word.substring(0, word.indexOf('<'))));
+
+          final match = inlineRegex.firstMatch(word);
+          if (match != null) {
+            parser.addNode(md.Element.text(match[1]!, match[2]!));
+          }
+
+          parser.addNode(
+              md.Text("${word.substring(word.lastIndexOf('>') + 1)} "));
+          continue;
+        }
+        parser.addNode(md.Text('$word '));
+      }
+    } else {
+      parser.addNode(md.Element.text('code', matched));
+    }
+
+    return true;
+  }
+}

--- a/lib/ui/views/ib/syntaxes/ib_inline_html_syntax.dart
+++ b/lib/ui/views/ib/syntaxes/ib_inline_html_syntax.dart
@@ -2,11 +2,11 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:markdown/markdown.dart' as md;
 
 class IbInlineHtmlSyntax extends md.InlineSyntax {
-  IbInlineHtmlSyntax({required this.builders}) : super(_pattern);
+  IbInlineHtmlSyntax({required this.builders}) : super(Pattern);
 
   Map<String, MarkdownElementBuilder> builders;
 
-  static const String _pattern = r'<(\S*?)[^>]*>(.*?)<\/\1>|<.*?\/>';
+  static const String Pattern = r'<(\S*?)[^>]*>(.*?)<\/\1>|<.*?\/>';
 
   @override
   bool onMatch(md.InlineParser parser, Match match) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -318,7 +318,7 @@ packages:
       path: "packages/flutter_markdown"
       ref: HEAD
       resolved-ref: "0072ff221b16f8947f2f80cfb48fc21d62985ee7"
-      url: "git://github.com/CircuitVerse/packages.git"
+      url: "https://github.com/CircuitVerse/packages.git"
     source: git
     version: "0.6.4"
   flutter_math_fork:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
     sdk: flutter
   flutter_markdown:
     git:
-      url: git://github.com/CircuitVerse/packages.git
+      url: https://github.com/CircuitVerse/packages.git
       path: packages/flutter_markdown
   flutter_math_fork: ^0.5.0
   flutter_summernote: ^1.0.0


### PR DESCRIPTION
Fixes #196 

Describe the changes you have made in this PR - 
`Inline HTML Elements` between backticks (\`) are not parsed. So, I have split the content between \` and if there exist HTML elements in between them then omitted the `.

![Screenshot from 2022-03-08 11-18-16](https://user-images.githubusercontent.com/77198905/157174578-c14af0db-a0df-4b53-ac95-0ff3349c548d.png)


Screenshots of the changes (If any) -
![WhatsApp Image 2022-03-08 at 10 54 20 AM](https://user-images.githubusercontent.com/77198905/157171901-d993ee45-e4ec-479d-86b7-6080f5ac8185.jpeg)

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.
