### PR TITLE
Interactive book throwing error , markdown builder bug fixed #237

### DIFF
--- a/lib/ui/views/ib/ib_page_view.dart
+++ b/lib/ui/views/ib/ib_page_view.dart
@@ -183,10 +183,16 @@ class _IbPageViewState extends State<IbPageView> {
       'mark': HighlightBuilder(selectable: _selectable),
     };
 
+    // Temporary fix for bug in flutter_markdown package
+    // Prevent crash of app by adding an invisible character at the end of the string, 
+    // So that if any inline element is at the end of the markdown , it can be grouped with the invisible character and not crash the app
+    String content = data.content;
+    content = "$content‎ ";
+
     return MarkdownBody(
       key: UniqueKey(),
       shrinkWrap: false,
-      data: data.content,
+      data: content,
       selectable: _selectable,
       imageDirectory: EnvironmentConfig.IB_BASE_URL,
       imageBuilder: _buildMarkdownImage,


### PR DESCRIPTION
#### Fixes #
@tachyons  
This issue is an reference to the bug in issue #216 

I have go through the codes, and debugged the code.  
I found the issue is actually in `markdown` library which is used by `flutter_markdown`. The bug is that if there is any **inline element** (image, some special widget.) at the end of markdown , sometimes it cant group it with adjacent child nodes of AST. and the MarkdownBuilder throw error .

To prevent the issue in this app, I am adding _**an special invisibie character**_ to the end of markdown. So that if there is any inline element left behind , it can group with the invisible text. We cant use the space, as during the parsing process the right and left whitespaces trimmed.

That invisibile character is between the bracket. -> (‎ )  Unicode value -> U+200e

I have tested all the parts of interactive book. It has no issue now.

#### Describe the changes you have made in this PR -
In ./lib/ui/views/ib/ib_page_view.dart 
I have update  the content  before send it to markdown builder, like below
```
content = content  + invisible character
```

#### Screenshots of the changes (If any) -
The issue was found in `Interactive Book > Sequential SSI > Clock Signals` page. I am attaching an image of that now.


<img src="https://user-images.githubusercontent.com/57363826/206244057-6cfaf680-a446-4096-9be4-699eb04c7f3a.jpg" data-canonical-src="https://user-images.githubusercontent.com/57363826/206244057-6cfaf680-a446-4096-9be4-699eb04c7f3a.jpg" width="300"  />

But I have checked all the pages of Interactive book, And no issue found. Everything rendering perfectly .

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.
