### PR TITLE
[fix#266] Show a spinner when the API request for Star an repo is running 

### DIFF
--- a/lib/ui/views/projects/project_details_view.dart
+++ b/lib/ui/views/projects/project_details_view.dart
@@ -308,7 +308,11 @@ class _ProjectDetailsViewState extends State<ProjectDetailsView> {
 
   Widget _buildStarProjectButton() {
     return _isBeingStarred
-        ? const CircularProgressIndicator()
+        ? const SizedBox(
+            height: 30,
+            width: 30,
+            child: CircularProgressIndicator(),
+          )
         : InkWell(
             onTap: onStarProjectPressed,
             child: Container(

--- a/lib/ui/views/projects/project_details_view.dart
+++ b/lib/ui/views/projects/project_details_view.dart
@@ -34,6 +34,7 @@ class _ProjectDetailsViewState extends State<ProjectDetailsView> {
   final DialogService _dialogService = locator<DialogService>();
   late ProjectDetailsViewModel _model;
   final _formKey = GlobalKey<FormState>();
+  bool _isBeingStarred = false;
   late String _emails;
   late Project _recievedProject;
   final GlobalKey<CVFlatButtonState> addButtonGlobalKey =
@@ -288,6 +289,7 @@ class _ProjectDetailsViewState extends State<ProjectDetailsView> {
   }
 
   Future<void> onStarProjectPressed() async {
+    _isBeingStarred = true;
     await _model.toggleStarForProject(_recievedProject.id);
 
     if (_model.isSuccess(_model.TOGGLE_STAR)) {
@@ -301,23 +303,26 @@ class _ProjectDetailsViewState extends State<ProjectDetailsView> {
         _model.errorMessageFor(_model.TOGGLE_STAR),
       );
     }
+    _isBeingStarred = false;
   }
 
   Widget _buildStarProjectButton() {
-    return InkWell(
-      onTap: onStarProjectPressed,
-      child: Container(
-        padding: const EdgeInsets.all(4),
-        decoration: BoxDecoration(
-          color: CVTheme.primaryColor,
-          borderRadius: BorderRadius.circular(4),
-        ),
-        child: Icon(
-          _model.isProjectStarred ? Icons.star : Icons.star_border,
-          color: Colors.white,
-        ),
-      ),
-    );
+    return _isBeingStarred
+        ? const CircularProgressIndicator()
+        : InkWell(
+            onTap: onStarProjectPressed,
+            child: Container(
+              padding: const EdgeInsets.all(4),
+              decoration: BoxDecoration(
+                color: CVTheme.primaryColor,
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Icon(
+                _model.isProjectStarred ? Icons.star : Icons.star_border,
+                color: Colors.white,
+              ),
+            ),
+          );
   }
 
   Future<void> onAddCollaboratorsPressed(BuildContext context) async {


### PR DESCRIPTION
Fixes #266 

Describe the changes you have made in this PR -

- Added a boolean to check if the repo is being starred.
- Added a CircularProgressIndicator with a ternary operator.

Screenshots of the changes (If any) -


https://user-images.githubusercontent.com/91044746/223662186-fb195cfb-222d-4bf9-92c4-6ed2e4959e45.mp4

