### PR TITLE
Add automated continous deployment workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,7 @@ jobs:
         id: changelog
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          config: "angular" # or any other preset
+          config: "angular"
           output-file: "CHANGELOG.md"
           version: ${{ steps.extract_version.outputs.VERSION }}
 
@@ -47,16 +47,17 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git tag ${{ steps.extract_version.outputs.VERSION }}${{ inputs.release_type == 'beta' && '-beta' || '' }} -a -m "Release ${{ steps.extract_version.outputs.VERSION }}${{ inputs.release_type == 'beta' && '-beta' || '' }}"
-          git push origin ${{ steps.extract_version.outputs.VERSION }}${{ inputs.release_type == 'beta' && '-beta' || '' }}
+          TAG_NAME="v${{ steps.extract_version.outputs.VERSION }}-${{ inputs.release_type }}"
+          git tag $TAG_NAME -a -m "Release $TAG_NAME"
+          git push origin $TAG_NAME
 
       - name: Create GitHub Release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.extract_version.outputs.VERSION }}${{ inputs.release_type == 'beta' && '-beta' || '' }}
-          release_name: Release ${{ steps.extract_version.outputs.VERSION }}${{ inputs.release_type == 'beta' && '-beta' || '' }}
+          tag_name: "v${{ steps.extract_version.outputs.VERSION }}-${{ inputs.release_type }}"
+          release_name: "Release v${{ steps.extract_version.outputs.VERSION }}-${{ inputs.release_type }}"
           body: ${{ steps.changelog.outputs.clean_changelog }}
           draft: false
           prerelease: ${{ inputs.release_type == 'beta' }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,8 +1,15 @@
-name: CD
+name: Release and Deploy
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (beta or prod)'
+        required: true
+        type: choice
+        options:
+          - beta
+          - prod
 
 env:
   FB_APP_ID: ${{ secrets.FB_APP_ID }}
@@ -14,12 +21,52 @@ env:
   RELEASE_KEYSTORE_PROPERTIES: ${{ secrets.RELEASE_KEYSTORE_PROPERTIES }}
 
 jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Extract Version from pubspec.yaml
+        id: extract_version
+        run: |
+          VERSION=$(grep "version:" pubspec.yaml | awk '{print $2}')
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Generate Changelog
+        uses: TriPSs/conventional-changelog-action@v3
+        id: changelog
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          config: "angular" # or any other preset
+          output-file: "CHANGELOG.md"
+          version: ${{ steps.extract_version.outputs.VERSION }}
+
+      - name: Create Release Tag
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git tag ${{ steps.extract_version.outputs.VERSION }}${{ inputs.release_type == 'beta' && '-beta' || '' }} -a -m "Release ${{ steps.extract_version.outputs.VERSION }}${{ inputs.release_type == 'beta' && '-beta' || '' }}"
+          git push origin ${{ steps.extract_version.outputs.VERSION }}${{ inputs.release_type == 'beta' && '-beta' || '' }}
+
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.extract_version.outputs.VERSION }}${{ inputs.release_type == 'beta' && '-beta' || '' }}
+          release_name: Release ${{ steps.extract_version.outputs.VERSION }}${{ inputs.release_type == 'beta' && '-beta' || '' }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}
+          draft: false
+          prerelease: ${{ inputs.release_type == 'beta' }}
+
   deploy:
+    needs: release
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event.release.target_commitish == 'master'
     env:
-      RELEASE_TYPE: ${{ contains(github.event.release.tag_name, 'beta') && 'beta' || 'prod' }}
+      RELEASE_TYPE: ${{ inputs.release_type }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Current deployment strategy includes manually creating release notes using conventional commits, this can be improved by automating this

cc @manjotsidhu 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a manual release and deploy workflow allowing users to select the release type (beta or prod) when triggering a release.
	- Enhanced the release process with automated generation of release tags and changelogs for smoother deployments.
	- Added a new job for managing the release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->