### PR TITLE
Remove flutter summernote insead use flutter quill

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_quill/flutter_quill.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/cv_theme.dart';
 import 'package:mobile_app/locator.dart';
@@ -32,6 +33,8 @@ class CircuitVerseMobile extends StatelessWidget {
       DeviceOrientation.portraitUp,
       DeviceOrientation.portraitDown,
     ]);
+    var delegates = AppLocalizations.localizationsDelegates.toList();
+    delegates.add(FlutterQuillLocalizations.delegate);
 
     return KeyboardDismissOnTap(
       child: ThemeProvider(
@@ -73,8 +76,7 @@ class CircuitVerseMobile extends StatelessWidget {
             builder:
                 (themeContext) => GetMaterialApp(
                   title: 'CircuitVerse Mobile',
-                  localizationsDelegates:
-                      AppLocalizations.localizationsDelegates,
+                  localizationsDelegates: delegates,
                   supportedLocales: AppLocalizations.supportedLocales,
                   onGenerateTitle:
                       (BuildContext context) =>

--- a/lib/ui/components/cv_html_editor.dart
+++ b/lib/ui/components/cv_html_editor.dart
@@ -1,38 +1,60 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_summernote/flutter_summernote.dart';
+import 'package:flutter_quill/flutter_quill.dart';
 import 'package:mobile_app/cv_theme.dart';
 
-class CVHtmlEditor extends StatelessWidget {
+class CVHtmlEditor extends StatefulWidget {
   const CVHtmlEditor({
-    required this.editorKey,
+    required this.controller,
     this.hasAttachment = true,
     this.height = 300,
     super.key,
   });
 
-  final GlobalKey<FlutterSummernoteState> editorKey;
+  final QuillController controller;
   final double height;
   final bool hasAttachment;
 
   @override
+  State<CVHtmlEditor> createState() => _CVHtmlEditorState();
+}
+
+class _CVHtmlEditorState extends State<CVHtmlEditor> {
+  @override
   Widget build(BuildContext context) {
-    return FlutterSummernote(
-      height: height,
+    QuillSimpleToolbarConfig toolbarConfig = QuillSimpleToolbarConfig(
+      showFontFamily: false,
+      showFontSize: false,
+      showColorButton: false,
+      showBackgroundColorButton: false,
+      showClearFormat: false,
+      showHeaderStyle: false,
+      showListCheck: false,
+      showCodeBlock: true,
+      showAlignmentButtons: true,
+      showQuote: false,
+      showIndent: false,
+      showSearchButton: false,
+    );
+    return Container(
       decoration: BoxDecoration(
-        color: CVTheme.htmlEditorBg,
+        color: CVTheme.boxBg(context),
         border: Border.all(color: CVTheme.primaryColorDark),
       ),
-      key: editorKey,
-      hasAttachment: hasAttachment,
-      customToolbar: """
-          [
-            ['view', ['codeview', 'undo', 'redo']],
-            ['style', ['bold', 'italic', 'underline', 'clear']],
-            ['font', ['strikethrough', 'superscript', 'subscript']],
-            ['para', ['ul', 'ol', 'paragraph']],
-            ['insert', ['link', 'hr']]
-          ]
-        """,
+      child: Column(
+        children: [
+          QuillSimpleToolbar(
+            controller: widget.controller,
+            config: toolbarConfig,
+          ),
+          ConstrainedBox(
+            constraints: BoxConstraints(
+              minHeight: widget.height,
+              maxHeight: widget.height,
+            ),
+            child: QuillEditor.basic(controller: widget.controller),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/ui/views/groups/add_assignment_view.dart
+++ b/lib/ui/views/groups/add_assignment_view.dart
@@ -1,6 +1,6 @@
 import 'package:datetime_picker_formfield/datetime_picker_formfield.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_summernote/flutter_summernote.dart';
+import 'package:flutter_quill/flutter_quill.dart';
 import 'package:get/get.dart';
 import 'package:intl/intl.dart';
 import 'package:mobile_app/cv_theme.dart';
@@ -31,7 +31,7 @@ class _AddAssignmentViewState extends State<AddAssignmentView> {
   final _formKey = GlobalKey<FormState>();
   String _gradingScale = 'No Scale';
   late String _name;
-  final GlobalKey<FlutterSummernoteState> _descriptionEditor = GlobalKey();
+  final QuillController _controller = QuillController.basic();
   late DateTime _deadline;
   final List<String> _restrictions = [];
   final List<String> _gradingOptions = [
@@ -55,7 +55,7 @@ class _AddAssignmentViewState extends State<AddAssignmentView> {
   Widget _buildDescriptionInput() {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: CVHtmlEditor(editorKey: _descriptionEditor),
+      child: CVHtmlEditor(controller: _controller),
     );
   }
 
@@ -209,8 +209,7 @@ class _AddAssignmentViewState extends State<AddAssignmentView> {
       // [ISSUE] [html_editor] Throws error in Tests
       String _descriptionEditorText;
       try {
-        _descriptionEditorText =
-            await _descriptionEditor.currentState!.getText();
+        _descriptionEditorText = _controller.document.toPlainText();
       } on NoSuchMethodError {
         debugPrint(
           'Handled html_editor error. NOTE: This should only throw during tests.',

--- a/lib/ui/views/groups/add_assignment_view.dart
+++ b/lib/ui/views/groups/add_assignment_view.dart
@@ -42,6 +42,12 @@ class _AddAssignmentViewState extends State<AddAssignmentView> {
   ];
   bool _isRestrictionEnabled = false;
 
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
   Widget _buildNameInput() {
     return CVTextField(
       label: 'Name',

--- a/lib/ui/views/groups/update_assignment_view.dart
+++ b/lib/ui/views/groups/update_assignment_view.dart
@@ -2,8 +2,8 @@ import 'dart:convert';
 
 import 'package:datetime_picker_formfield/datetime_picker_formfield.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_quill/flutter_quill.dart';
 import 'package:get/get.dart';
-import 'package:flutter_summernote/flutter_summernote.dart';
 import 'package:intl/intl.dart';
 import 'package:mobile_app/cv_theme.dart';
 import 'package:mobile_app/data/restriction_elements.dart';
@@ -33,7 +33,7 @@ class _UpdateAssignmentViewState extends State<UpdateAssignmentView> {
   late UpdateAssignmentViewModel _model;
   final _formKey = GlobalKey<FormState>();
   late String _name;
-  final GlobalKey<FlutterSummernoteState> _descriptionEditor = GlobalKey();
+  final QuillController _controller = QuillController.basic();
   late DateTime _deadline;
   List _restrictions = [];
   bool _isRestrictionEnabled = false;
@@ -58,7 +58,7 @@ class _UpdateAssignmentViewState extends State<UpdateAssignmentView> {
   Widget _buildDescriptionInput() {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: CVHtmlEditor(editorKey: _descriptionEditor),
+      child: CVHtmlEditor(controller: _controller),
     );
   }
 
@@ -189,8 +189,7 @@ class _UpdateAssignmentViewState extends State<UpdateAssignmentView> {
       // [ISSUE] [html_editor] Throws error in Tests
       String _descriptionEditorText;
       try {
-        _descriptionEditorText =
-            await _descriptionEditor.currentState!.getText();
+        _descriptionEditorText = _controller.document.toPlainText();
       } on NoSuchMethodError {
         debugPrint(
           'Handled html_editor error. NOTE: This should only throw during tests.',

--- a/lib/ui/views/groups/update_assignment_view.dart
+++ b/lib/ui/views/groups/update_assignment_view.dart
@@ -45,6 +45,12 @@ class _UpdateAssignmentViewState extends State<UpdateAssignmentView> {
     _isRestrictionEnabled = _restrictions.isNotEmpty;
   }
 
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
   Widget _buildNameInput() {
     return CVTextField(
       initialValue: widget.assignment.attributes.name,

--- a/lib/ui/views/projects/edit_project_view.dart
+++ b/lib/ui/views/projects/edit_project_view.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_quill/flutter_quill.dart';
 import 'package:get/get.dart';
-import 'package:flutter_summernote/flutter_summernote.dart';
 import 'package:mobile_app/cv_theme.dart';
 import 'package:mobile_app/locator.dart';
 import 'package:mobile_app/models/projects.dart';
@@ -29,7 +29,7 @@ class _EditProjectViewState extends State<EditProjectView> {
   final _formKey = GlobalKey<FormState>();
   late String _name, _projectAccessType;
   late List<String> _tags;
-  final GlobalKey<FlutterSummernoteState> _descriptionEditor = GlobalKey();
+  final QuillController _controller = QuillController.basic();
 
   final _nameFocusNode = FocusNode();
   final _tagsListFocusNode = FocusNode();
@@ -109,7 +109,7 @@ class _EditProjectViewState extends State<EditProjectView> {
   Widget _buildDescriptionInput() {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: CVHtmlEditor(editorKey: _descriptionEditor),
+      child: CVHtmlEditor(controller: _controller),
     );
   }
 
@@ -123,7 +123,7 @@ class _EditProjectViewState extends State<EditProjectView> {
         widget.project.id,
         name: _name,
         projectAccessType: _projectAccessType,
-        description: await _descriptionEditor.currentState!.getText(),
+        description: _controller.document.toPlainText(),
         tagsList: _tags,
       );
 

--- a/lib/ui/views/projects/edit_project_view.dart
+++ b/lib/ui/views/projects/edit_project_view.dart
@@ -38,6 +38,7 @@ class _EditProjectViewState extends State<EditProjectView> {
   void dispose() {
     _nameFocusNode.dispose();
     _tagsListFocusNode.dispose();
+    _controller.dispose();
     super.dispose();
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -126,6 +126,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -198,6 +206,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dart_quill_delta:
+    dependency: transitive
+    description:
+      name: dart_quill_delta
+      sha256: bddb0b2948bd5b5a328f1651764486d162c59a8ccffd4c63e8b2c5e44be1dac4
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.8.3"
   dart_style:
     dependency: transitive
     description:
@@ -222,6 +238,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.3"
+  diff_match_patch:
+    dependency: transitive
+    description:
+      name: diff_match_patch
+      sha256: "2efc9e6e8f449d0abe15be240e2c2a3bcd977c8d126cfd70598aee60af35c0a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.1"
   fake_async:
     dependency: transitive
     description:
@@ -291,6 +315,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_colorpicker:
+    dependency: transitive
+    description:
+      name: flutter_colorpicker
+      sha256: "969de5f6f9e2a570ac660fb7b501551451ea2a1ab9e2097e89475f60e07816ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   flutter_facebook_auth:
     dependency: "direct main"
     description:
@@ -419,6 +451,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  flutter_keyboard_visibility_temp_fork:
+    dependency: transitive
+    description:
+      name: flutter_keyboard_visibility_temp_fork
+      sha256: e3d02900640fbc1129245540db16944a0898b8be81694f4bf04b6c985bed9048
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.5"
   flutter_keyboard_visibility_web:
     dependency: transitive
     description:
@@ -472,6 +512,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.27"
+  flutter_quill:
+    dependency: "direct main"
+    description:
+      name: flutter_quill
+      sha256: cdc3802700bf6718b8286ec6c999094f45abb885b5b3b65380f25d1b4369032d
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.1.1"
+  flutter_quill_delta_from_html:
+    dependency: transitive
+    description:
+      name: flutter_quill_delta_from_html
+      sha256: "79405765612016de9de2361be86383360b0b43a6bf88b818c079a953583f1849"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   flutter_secure_storage:
     dependency: transitive
     description:
@@ -520,15 +576,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
-  flutter_summernote:
-    dependency: "direct main"
-    description:
-      path: "."
-      ref: HEAD
-      resolved-ref: ef0924f1b3d2244677e25df4eb64c01f1dab45c6
-      url: "https://github.com/realaashil/flutter_summernote"
-    source: git
-    version: "1.1.1"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -1188,6 +1235,78 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  quill_native_bridge:
+    dependency: transitive
+    description:
+      name: quill_native_bridge
+      sha256: bda0f0ad9bc160dcdd4bd2b378a7ae8bdb55c3d4b7301bf739d5e3b065ee5e82
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.0"
+  quill_native_bridge_android:
+    dependency: transitive
+    description:
+      name: quill_native_bridge_android
+      sha256: b75c7e6ede362a7007f545118e756b1f19053994144ec9eda932ce5e54a57569
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1+2"
+  quill_native_bridge_ios:
+    dependency: transitive
+    description:
+      name: quill_native_bridge_ios
+      sha256: d23de3cd7724d482fe2b514617f8eedc8f296e120fb297368917ac3b59d8099f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
+  quill_native_bridge_linux:
+    dependency: transitive
+    description:
+      name: quill_native_bridge_linux
+      sha256: "5fcc60cab2ab9079e0746941f05c5ca5fec85cc050b738c8c8b9da7c09da17eb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
+  quill_native_bridge_macos:
+    dependency: transitive
+    description:
+      name: quill_native_bridge_macos
+      sha256: "1c0631bd1e2eee765a8b06017c5286a4e829778f4585736e048eb67c97af8a77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
+  quill_native_bridge_platform_interface:
+    dependency: transitive
+    description:
+      name: quill_native_bridge_platform_interface
+      sha256: ea48bd12bf426741747ec8a575b122350971f338a75049099b349c63447582a2
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1+1"
+  quill_native_bridge_web:
+    dependency: transitive
+    description:
+      name: quill_native_bridge_web
+      sha256: e7e55047d68f1a88574c26dbe3f12988f49d07740590d8fc6280028bbde5b908
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
+  quill_native_bridge_windows:
+    dependency: transitive
+    description:
+      name: quill_native_bridge_windows
+      sha256: "60e50d74238f22ceb43113d9a42b6627451dab9fc27f527b979a32051cf1da45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
   random_string:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,9 +31,6 @@ dependencies:
     sdk: flutter
   flutter_markdown: ^0.7.6+2
   flutter_math_fork: ^0.7.3
-  flutter_summernote:
-    git:
-      url: https://github.com/realaashil/flutter_summernote
   flutter_svg: ^2.0.17
   flutter_typeahead: ^5.2.0
   fluttericon: ^2.0.0
@@ -67,6 +64,7 @@ dependencies:
   http: any
   markdown: any
   webview_flutter: any
+  flutter_quill: ^11.1.1
 dev_dependencies:
   build_runner: ^2.1.7
   flutter_lints: ^5.0.0

--- a/test/ui_tests/groups/add_assignment_view_test.dart
+++ b/test/ui_tests/groups/add_assignment_view_test.dart
@@ -1,5 +1,6 @@
 import 'package:datetime_picker_formfield/datetime_picker_formfield.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/locator.dart';
@@ -37,6 +38,8 @@ void main() {
           onGenerateRoute: CVRouter.generateRoute,
           navigatorObservers: [mockObserver],
           home: const AddAssignmentView(groupId: 'Test'),
+          localizationsDelegates:
+              FlutterQuillLocalizations.localizationsDelegates,
         ),
       );
 

--- a/test/ui_tests/groups/group_details_view_test.dart
+++ b/test/ui_tests/groups/group_details_view_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/locator.dart';
@@ -65,6 +66,8 @@ void main() {
           onGenerateRoute: CVRouter.generateRoute,
           navigatorObservers: [mockObserver],
           home: GroupDetailsView(group: group),
+          localizationsDelegates:
+              FlutterQuillLocalizations.localizationsDelegates,
         ),
       );
 

--- a/test/ui_tests/groups/update_assignment_view_test.dart
+++ b/test/ui_tests/groups/update_assignment_view_test.dart
@@ -1,5 +1,6 @@
 import 'package:datetime_picker_formfield/datetime_picker_formfield.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/locator.dart';
@@ -41,6 +42,8 @@ void main() {
         GetMaterialApp(
           onGenerateRoute: CVRouter.generateRoute,
           navigatorObservers: [mockObserver],
+          localizationsDelegates:
+              FlutterQuillLocalizations.localizationsDelegates,
           home: UpdateAssignmentView(assignment: _assignment),
         ),
       );

--- a/test/ui_tests/profile/edit_profile_view_test.dart
+++ b/test/ui_tests/profile/edit_profile_view_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/locator.dart';
@@ -56,6 +57,8 @@ void main() {
         GetMaterialApp(
           onGenerateRoute: CVRouter.generateRoute,
           navigatorObservers: [mockObserver],
+          localizationsDelegates:
+              FlutterQuillLocalizations.localizationsDelegates,
           home: const EditProfileView(),
         ),
       );


### PR DESCRIPTION
## Fixes 
Closes #265

## Describe the changes you have made in this PR -
Switched to flutter quill for text editing instead of flutter summernote

## Screenshots of the changes (If any) -
![Screenshot_20250320-203849](https://github.com/user-attachments/assets/7c6acb74-01b6-4265-a0f5-d40e09dead36)



Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upgraded the text editing experience with a modern toolbar offering new formatting options.
  - Enhanced localization support to provide a more seamless multi-language experience.

- **Refactor**
  - Transitioned from the legacy editor to a dynamic, stateful design for improved responsiveness across assignment and project views.

- **Chores**
  - Updated dependencies to adopt the new text editor library while removing the previous implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->