### PR TITLE
fix(project_star): Show spinner when toggleing star

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -6,17 +6,9 @@ gradle-wrapper.jar
 /local.properties
 GeneratedPluginRegistrant.java
 
-# fastlane specific
-**/fastlane/report.xml
-
-# deliver temporary files
-**/fastlane/Preview.html
-
-# snapshot generated screenshots
-**/fastlane/screenshots
-
-# scan temporary files
-**/fastlane/test_output
-
-# supply json key
-**/supply_json_key.json
+app/.cxx
+# Remember to never publicly share your keystore.
+# See https://flutter.dev/to/reference-keystore
+key.properties
+**/*.keystore
+**/*.jks

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -6,6 +6,21 @@ gradle-wrapper.jar
 /local.properties
 GeneratedPluginRegistrant.java
 
+# fastlane specific
+**/fastlane/report.xml
+
+# deliver temporary files
+**/fastlane/Preview.html
+
+# snapshot generated screenshots
+**/fastlane/screenshots
+
+# scan temporary files
+**/fastlane/test_output
+
+# supply json key
+**/supply_json_key.json
+
 app/.cxx
 # Remember to never publicly share your keystore.
 # See https://flutter.dev/to/reference-keystore

--- a/lib/ui/views/projects/project_details_view.dart
+++ b/lib/ui/views/projects/project_details_view.dart
@@ -292,6 +292,7 @@ class _ProjectDetailsViewState extends State<ProjectDetailsView> {
   }
 
   Future<void> onStarProjectPressed() async {
+    if (_model.isBusy(_model.TOGGLE_STAR)) return;
     await _model.toggleStarForProject(_recievedProject.id);
 
     if (_model.isSuccess(_model.TOGGLE_STAR)) {
@@ -316,10 +317,20 @@ class _ProjectDetailsViewState extends State<ProjectDetailsView> {
           color: CVTheme.primaryColor,
           borderRadius: BorderRadius.circular(4),
         ),
-        child: Icon(
-          _model.isProjectStarred ? Icons.star : Icons.star_border,
-          color: Colors.white,
-        ),
+        child:
+            _model.isBusy(_model.TOGGLE_STAR)
+                ? const SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(
+                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                    strokeWidth: 3,
+                  ),
+                )
+                : Icon(
+                  _model.isProjectStarred ? Icons.star : Icons.star_border,
+                  color: Colors.white,
+                ),
       ),
     );
   }


### PR DESCRIPTION
Fixes #
Closes  #266 
Describe the changes you have made in this PR -

Screenshots of the changes (If any) -

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the star project button with dynamic visual feedback. When toggling the star status, a loading spinner is displayed to indicate that processing is underway, preventing multiple actions during the operation.
  
- **Chores**
  - Updated `.gitignore` to remove Fastlane-related entries and added entries for keystore files and specific directories, with reminders regarding keystore sharing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->