### PR TITLE
email-fixed-fallback-email-and-copy-email-mechanism

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,13 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <queries>
+            <!-- To support mailto URLs -->
+            <intent>
+                <action android:name="android.intent.action.VIEW" />
+                <data android:scheme="mailto" />
+            </intent>
+        </queries>
     <application
         android:name="${applicationName}"
         android:label="CircuitVerse"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,14 @@
                 <action android:name="android.intent.action.VIEW" />
                 <data android:scheme="mailto" />
             </intent>
+            <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="tel" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="sms" />
+        </intent>
         </queries>
     <application
         android:name="${applicationName}"

--- a/lib/ui/components/cv_social_card.dart
+++ b/lib/ui/components/cv_social_card.dart
@@ -20,7 +20,7 @@ class CircuitVerseSocialCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () async {
-        launchURL(url);
+        launchURL(context,url);
       },
       child: Card(
         color:

--- a/lib/ui/views/about/components/contributor_avatar.dart
+++ b/lib/ui/views/about/components/contributor_avatar.dart
@@ -12,7 +12,7 @@ class ContributorAvatar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () => launchURL(contributor.htmlUrl),
+      onTap: () => launchURL(context,contributor.htmlUrl),
       child: Tooltip(
         message: contributor.login,
         child: Container(

--- a/lib/ui/views/contributors/components/contributors_donate_card.dart
+++ b/lib/ui/views/contributors/components/contributors_donate_card.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_app/utils/url_launcher.dart';
-
 class ContributeDonateCard extends StatelessWidget {
   const ContributeDonateCard({
     super.key,
@@ -21,7 +20,7 @@ class ContributeDonateCard extends StatelessWidget {
         const SizedBox(height: 10),
         GestureDetector(
           onTap: () async {
-            launchURL(url);
+            launchURL(context,url);
           },
           child: Container(
             decoration: BoxDecoration(

--- a/lib/ui/views/ib/ib_page_view.dart
+++ b/lib/ui/views/ib/ib_page_view.dart
@@ -128,7 +128,7 @@ class _IbPageViewState extends State<IbPageView> {
       } else {
         // Try to navigate to another page using url
         // (TODO) We need [IbLandingViewModel] to be able to get Chapter using [httpUrl]
-        launchURL(href);
+        launchURL(context,href);
       }
     }
 

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -1,9 +1,34 @@
 import 'package:url_launcher/url_launcher_string.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/material.dart';
 
-void launchURL(String url) async {
-  if (await canLaunchUrlString(url)) {
-    await launchUrlString(url);
+void launchURL(BuildContext context,String url) async {
+  if (url.startsWith('mailto:')) {
+    final Uri uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(
+        uri,
+        mode: LaunchMode.externalApplication,
+      );
+    } else {
+      final email = url.replaceFirst('mailto:', '');
+      Clipboard.setData(ClipboardData(text: email));
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text("Email copied to clipboard: $email"),
+          duration: Duration(seconds: 1),
+        ),
+      );
+      await Future.delayed(Duration(seconds: 1));
+      await launchUrlString(
+        'https://mail.google.com/mail/u/0/?fs=1&to=$email&tf=cm',
+        mode: LaunchMode.externalApplication,
+      );
+    }
   } else {
-    throw 'Could not launch $url';
+    if (await canLaunchUrlString(url)) {
+      await launchUrlString(url);
+    } 
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,7 +58,7 @@ dependencies:
   theme_provider: ^0.6.0
   timeago: ^3.1.0
   transparent_image: ^2.0.0
-  url_launcher: ^6.0.18
+  url_launcher: ^6.3.0
   flutter_facebook_auth: ^6.0.4
 
   http: any


### PR DESCRIPTION
Fixes #

Email Issue Fixed

*Fixed the Email Us button on the chips and direct 'mailto's*

Introduced a fallback method for email links: If the email link (mailto) is not working on Android, it opens Gmail in Chrome so that users can send emails to the organization. Integrated a copy feature for the email: When the email link can’t be accessed, the address gets copied, and the user is notified.

*Also added the SMS and TEL Intents in the intent so that it can come in handy in the future if someone wants to use the phone number or SMS directly in the application* 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Fixed the Email button on the chips and email hyperlinks ensuring the user experience is better.
  - Improved URL launching across the app, ensuring that tapping on social cards, contributor avatars, and donation cards now consistently provides context-aware navigation.
  - Enhanced email link handling: if an email link cannot be opened conventionally, the email address is automatically copied and a notification is displayed for a smoother user experience.
  - SMS and Tel Intent Added: SMS and TEL intents have been integrated, allowing seamless future integration of phone number dialing or SMS sending directly within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->