### PR TITLE
added empty ui widgets for notifications , favourites , projects

### DIFF
--- a/lib/ui/views/notifications/notifications_view.dart
+++ b/lib/ui/views/notifications/notifications_view.dart
@@ -176,7 +176,7 @@ class NotificationsView extends StatelessWidget {
                       ),
                     ),
                   );
-                }).toList(),
+                }),
               ],
             ),
           ),

--- a/lib/ui/views/notifications/notifications_view.dart
+++ b/lib/ui/views/notifications/notifications_view.dart
@@ -76,6 +76,7 @@ class NotificationsView extends StatelessWidget {
 
         final hasNoNotifications = model.notifications.isEmpty;
         final hasNoUnread =
+            !hasNoNotifications &&
             model.value == 'Unread' &&
             model.notifications.every((n) => !n.attributes.unread);
 

--- a/lib/ui/views/notifications/notifications_view.dart
+++ b/lib/ui/views/notifications/notifications_view.dart
@@ -11,6 +11,60 @@ import 'package:provider/provider.dart';
 class NotificationsView extends StatelessWidget {
   const NotificationsView({super.key});
 
+  Widget _emptyState(BuildContext context, {required bool hasNoNotifications}) {
+    return Padding(
+      padding: const EdgeInsets.all(32.0),
+      child: Column(
+        children: <Widget>[
+          const SizedBox(height: 100),
+          _buildSubHeader(
+            context,
+            title:
+                hasNoNotifications
+                    ? "No notifications yet"
+                    : "No unread notifications",
+            subtitle:
+                hasNoNotifications
+                    ? "Your notifications will appear here"
+                    : "You have no unread notifications",
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSubHeader(
+    BuildContext context, {
+    required String title,
+    String? subtitle,
+  }) {
+    return Column(
+      children: [
+        Icon(Icons.notifications_none, size: 64, color: Colors.grey[400]),
+        const SizedBox(height: 24),
+        Text(
+          title,
+          style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+            fontSize: 20,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        if (subtitle != null) ...[
+          const SizedBox(height: 16),
+          Text(
+            subtitle,
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+              color: Colors.grey[600],
+              fontSize: 16,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return BaseView<NotificationsViewModel>(
@@ -19,6 +73,11 @@ class NotificationsView extends StatelessWidget {
         Future.delayed(const Duration(seconds: 1), () {
           context.read<CVLandingViewModel>().hasPendingNotif = model.hasUnread;
         });
+
+        final hasNoNotifications = model.notifications.isEmpty;
+        final hasNoUnread =
+            model.value == 'Unread' &&
+            model.notifications.every((n) => !n.attributes.unread);
 
         return Scaffold(
           body: SingleChildScrollView(
@@ -55,6 +114,9 @@ class NotificationsView extends StatelessWidget {
                     ),
                   ),
                 ),
+                if (hasNoNotifications || hasNoUnread)
+                  _emptyState(context, hasNoNotifications: hasNoNotifications),
+
                 ...model.notifications.map((notification) {
                   if (model.value == 'Unread' &&
                       !notification.attributes.unread) {
@@ -114,7 +176,7 @@ class NotificationsView extends StatelessWidget {
                       ),
                     ),
                   );
-                }),
+                }).toList(),
               ],
             ),
           ),

--- a/lib/ui/views/notifications/notifications_view.dart
+++ b/lib/ui/views/notifications/notifications_view.dart
@@ -123,69 +123,71 @@ class NotificationsView extends StatelessWidget {
                       context,
                       hasNoNotifications: hasNoNotifications,
                     ),
-                  ...model.notifications.map((notification) {
-                    if (model.value == 'Unread' &&
-                        !notification.attributes.unread) {
-                      return const SizedBox();
-                    }
 
-                    NotificationType type =
-                        notification.attributes.type.toLowerCase().contains(
-                              'star',
-                            )
-                            ? NotificationType.Star
-                            : NotificationType.Fork;
+                  ...model.notifications
+                      .where(
+                        (notification) =>
+                            model.value != 'Unread' ||
+                            notification.attributes.unread,
+                      )
+                      .map((notification) {
+                        NotificationType type =
+                            notification.attributes.type.toLowerCase().contains(
+                                  'star',
+                                )
+                                ? NotificationType.Star
+                                : NotificationType.Fork;
 
-                    return Card(
-                      shape: const RoundedRectangleBorder(
-                        borderRadius: BorderRadius.all(Radius.circular(10)),
-                      ),
-                      child: ListTile(
-                        contentPadding: const EdgeInsets.all(8.0),
-                        onTap: () {
-                          model.markAsRead(notification.id);
-                        },
-                        leading: Container(
-                          padding: const EdgeInsets.all(10),
-                          decoration: BoxDecoration(
-                            shape: BoxShape.circle,
-                            color: Colors.grey.withAlpha(50),
+                        return Card(
+                          margin: const EdgeInsets.symmetric(vertical: 6),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10),
                           ),
-                          child: Icon(
-                            type == NotificationType.Star
-                                ? FontAwesome.star
-                                : FontAwesome.fork,
-                            color: CVTheme.primaryColor,
+                          child: ListTile(
+                            contentPadding: const EdgeInsets.all(12),
+                            onTap: () => model.markAsRead(notification.id),
+                            leading: Container(
+                              padding: const EdgeInsets.all(10),
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: Colors.grey.withAlpha(50),
+                              ),
+                              child: Icon(
+                                type == NotificationType.Star
+                                    ? FontAwesome.star
+                                    : FontAwesome.fork,
+                                color: CVTheme.primaryColor,
+                                size: 20,
+                              ),
+                            ),
+                            title: Text(
+                              '${notification.attributes.params.user.data.attributes.name} '
+                              '${type == NotificationType.Fork ? 'forked' : 'starred'} your project '
+                              '${notification.attributes.params.project.name}',
+                              style: TextStyle(
+                                fontWeight:
+                                    notification.attributes.unread
+                                        ? FontWeight.bold
+                                        : FontWeight.normal,
+                              ),
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 2,
+                            ),
+                            subtitle: Text(
+                              DateFormat.yMMMMd().add_jm().format(
+                                notification.attributes.updatedAt,
+                              ),
+                              style: TextStyle(
+                                fontWeight:
+                                    notification.attributes.unread
+                                        ? FontWeight.bold
+                                        : FontWeight.normal,
+                              ),
+                              overflow: TextOverflow.ellipsis,
+                            ),
                           ),
-                        ),
-                        title: Text(
-                          '${notification.attributes.params.user.data.attributes.name} '
-                          '${type == NotificationType.Fork ? 'forked' : 'starred'} your project '
-                          '${notification.attributes.params.project.name}',
-                          style: TextStyle(
-                            fontWeight:
-                                notification.attributes.unread
-                                    ? FontWeight.bold
-                                    : FontWeight.normal,
-                          ),
-                          overflow: TextOverflow.ellipsis,
-                          maxLines: 2,
-                        ),
-                        subtitle: Text(
-                          DateFormat.yMMMMd().add_jm().format(
-                            notification.attributes.updatedAt,
-                          ),
-                          style: TextStyle(
-                            fontWeight:
-                                notification.attributes.unread
-                                    ? FontWeight.bold
-                                    : FontWeight.normal,
-                          ),
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                    );
-                  }),
+                        );
+                      }),
                 ],
               ),
             ),

--- a/lib/ui/views/profile/user_favourites_view.dart
+++ b/lib/ui/views/profile/user_favourites_view.dart
@@ -25,6 +25,47 @@ class _UserFavouritesViewState extends State<UserFavouritesView>
 
   Future<void> onProjectCardPressed(Project project) async {}
 
+  Widget _emptyState() {
+    return Padding(
+      padding: const EdgeInsets.all(32.0),
+      child: Column(
+        children: <Widget>[
+          const SizedBox(height: 100),
+          _buildSubHeader(
+            title: "No favorites yet!",
+            subtitle: "Explore projects and add them to your favorites list",
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSubHeader({required String title, String? subtitle}) {
+    return Column(
+      children: [
+        Text(
+          title,
+          style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+            fontSize: 20,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        if (subtitle != null) ...[
+          const SizedBox(height: 16),
+          Text(
+            subtitle,
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+              color: Colors.grey[600],
+              fontSize: 16,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     super.build(context);
@@ -41,24 +82,28 @@ class _UserFavouritesViewState extends State<UserFavouritesView>
         final _items = <Widget>[];
 
         if (model.isSuccess(model.FETCH_USER_FAVOURITES)) {
-          for (var project in model.userFavourites) {
-            _items.add(
-              ProjectCard(
-                project: project,
-                isHeaderFilled: false,
-                onPressed: () async {
-                  var _result = await Get.toNamed(
-                    ProjectDetailsView.id,
-                    arguments: project,
-                  );
-                  if (_result is bool) model.onProjectDeleted(project.id);
-                  if (_result is Project) {
-                    model.onProjectChanged(_result);
-                    context.read<ProfileViewModel>().updatedProject = _result;
-                  }
-                },
-              ),
-            );
+          if (model.userFavourites.isEmpty) {
+            _items.add(_emptyState());
+          } else {
+            for (var project in model.userFavourites) {
+              _items.add(
+                ProjectCard(
+                  project: project,
+                  isHeaderFilled: false,
+                  onPressed: () async {
+                    var _result = await Get.toNamed(
+                      ProjectDetailsView.id,
+                      arguments: project,
+                    );
+                    if (_result is bool) model.onProjectDeleted(project.id);
+                    if (_result is Project) {
+                      model.onProjectChanged(_result);
+                      context.read<ProfileViewModel>().updatedProject = _result;
+                    }
+                  },
+                ),
+              );
+            }
           }
         }
 

--- a/lib/ui/views/profile/user_projects_view.dart
+++ b/lib/ui/views/profile/user_projects_view.dart
@@ -23,6 +23,48 @@ class _UserProjectsViewState extends State<UserProjectsView>
   @override
   bool get wantKeepAlive => true;
 
+  Widget _emptyState() {
+    return Padding(
+      padding: const EdgeInsets.all(32.0),
+      child: Column(
+        children: <Widget>[
+          const SizedBox(height: 100),
+          _buildSubHeader(
+            title: "No Projects Yet!",
+            subtitle:
+                "Start fresh with a new design or fork existing templates",
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSubHeader({required String title, String? subtitle}) {
+    return Column(
+      children: [
+        Text(
+          title,
+          style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+            fontSize: 20,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        if (subtitle != null) ...[
+          const SizedBox(height: 16),
+          Text(
+            subtitle,
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+              color: Colors.grey[600],
+              fontSize: 16,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     super.build(context);
@@ -39,24 +81,28 @@ class _UserProjectsViewState extends State<UserProjectsView>
         final _items = <Widget>[];
 
         if (model.isSuccess(model.FETCH_USER_PROJECTS)) {
-          for (var project in model.userProjects) {
-            _items.add(
-              ProjectCard(
-                project: project,
-                isHeaderFilled: false,
-                onPressed: () async {
-                  var _result = await Get.toNamed(
-                    ProjectDetailsView.id,
-                    arguments: project,
-                  );
-                  if (_result is bool) model.onProjectDeleted(project.id);
-                  if (_result is Project) {
-                    model.onProjectChanged(_result);
-                    context.read<ProfileViewModel>().updatedProject = _result;
-                  }
-                },
-              ),
-            );
+          if (model.userProjects.isEmpty) {
+            _items.add(_emptyState());
+          } else {
+            for (var project in model.userProjects) {
+              _items.add(
+                ProjectCard(
+                  project: project,
+                  isHeaderFilled: false,
+                  onPressed: () async {
+                    var _result = await Get.toNamed(
+                      ProjectDetailsView.id,
+                      arguments: project,
+                    );
+                    if (_result is bool) model.onProjectDeleted(project.id);
+                    if (_result is Project) {
+                      model.onProjectChanged(_result);
+                      context.read<ProfileViewModel>().updatedProject = _result;
+                    }
+                  },
+                ),
+              );
+            }
           }
         }
 


### PR DESCRIPTION
Fixes #311 

Description of Changes

Added empty state handling to display helpful messages.

Introduced empty UI widgets for Notifications, Favorites, and Projects.

Screenshots of the changes (If any) -

![Screenshot from 2025-03-31 21-57-43](https://github.com/user-attachments/assets/12524310-1909-4071-92fc-0403d630873a)

![Screenshot from 2025-03-31 21-49-13](https://github.com/user-attachments/assets/45696746-1c43-4f23-81f4-ec1073fd7dad)

![image](https://github.com/user-attachments/assets/d4da6b64-23fc-4ace-b650-6cc029ecc51f)







Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the notifications view to display user-friendly messages when there are no notifications or unread alerts.
	- Updated the favorites view to show an informative empty state that encourages project exploration when no favorites are available.
	- Redesigned the projects view to present clear guidance with an empty state, prompting users to start a new design or explore existing templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->