### PR TITLE
Chips copy button

### DIFF
--- a/lib/ui/components/cv_social_card.dart
+++ b/lib/ui/components/cv_social_card.dart
@@ -42,9 +42,7 @@ class CircuitVerseSocialCard extends StatelessWidget {
                       right: -4,
                       child: IconButton(
                         onPressed: () {
-                          // Handle copy action here
                           Clipboard.setData(ClipboardData(text: url));
-                            // Show a snackbar indicating success
                             ScaffoldMessenger.of(context).showSnackBar(
                               SnackBar(
                                 content: const Text('Copied to clipboard!'),

--- a/lib/ui/components/cv_social_card.dart
+++ b/lib/ui/components/cv_social_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:mobile_app/cv_theme.dart';
 import 'package:mobile_app/utils/url_launcher.dart';
 import 'package:flutter/services.dart';
+
 class CircuitVerseSocialCard extends StatelessWidget {
   const CircuitVerseSocialCard({
     required this.imagePath,
@@ -24,9 +25,10 @@ class CircuitVerseSocialCard extends StatelessWidget {
         launchURL(url);
       },
       child: Card(
-        color: Theme.of(context).brightness == Brightness.dark
-            ? CVTheme.primaryColor
-            : CVTheme.primaryColorShadow,
+        color:
+            Theme.of(context).brightness == Brightness.dark
+                ? CVTheme.primaryColor
+                : CVTheme.primaryColorShadow,
         child: Padding(
           padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
           child: Row(
@@ -43,15 +45,15 @@ class CircuitVerseSocialCard extends StatelessWidget {
                       child: IconButton(
                         onPressed: () {
                           Clipboard.setData(ClipboardData(text: url));
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(
-                                content: const Text('Copied to clipboard!'),
-                                duration: const Duration(seconds: 2),
-                                behavior: SnackBarBehavior.floating,
-                              ),
-                            );
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: const Text('Copied to clipboard!'),
+                              duration: const Duration(seconds: 2),
+                              behavior: SnackBarBehavior.floating,
+                            ),
+                          );
                         },
-                        icon: Icon(Icons.copy), 
+                        icon: Icon(Icons.copy),
                         tooltip: 'Copy',
                       ),
                     ),
@@ -62,10 +64,12 @@ class CircuitVerseSocialCard extends StatelessWidget {
                           title,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                                fontWeight: FontWeight.bold,
-                                color: CVTheme.textColor(context),
-                              ),
+                          style: Theme.of(
+                            context,
+                          ).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: CVTheme.textColor(context),
+                          ),
                         ),
                         Text(
                           description,

--- a/lib/ui/components/cv_social_card.dart
+++ b/lib/ui/components/cv_social_card.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_app/cv_theme.dart';
 import 'package:mobile_app/utils/url_launcher.dart';
-
+import 'package:flutter/services.dart';
 class CircuitVerseSocialCard extends StatelessWidget {
   const CircuitVerseSocialCard({
     required this.imagePath,
@@ -20,38 +20,62 @@ class CircuitVerseSocialCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () async {
+        // print('Launching URL: $url');
         launchURL(url);
       },
       child: Card(
-        color:
-            Theme.of(context).brightness == Brightness.dark
-                ? CVTheme.primaryColor
-                : CVTheme.primaryColorShadow,
+        color: Theme.of(context).brightness == Brightness.dark
+            ? CVTheme.primaryColor
+            : CVTheme.primaryColorShadow,
         child: Padding(
           padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.start,
             children: <Widget>[
               Image.asset(imagePath, width: 48),
-              const SizedBox(width: 16),
+              const SizedBox(width: 20),
               Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Text(
-                      title,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold,
-                        color: CVTheme.textColor(context),
+                child: Stack(
+                  children: [
+                    Positioned(
+                      top: 0,
+                      right: -4,
+                      child: IconButton(
+                        onPressed: () {
+                          // Handle copy action here
+                          Clipboard.setData(ClipboardData(text: url));
+                            // Show a snackbar indicating success
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                content: const Text('Copied to clipboard!'),
+                                duration: const Duration(seconds: 2),
+                                behavior: SnackBarBehavior.floating,
+                              ),
+                            );
+                        },
+                        icon: Icon(Icons.copy), 
+                        tooltip: 'Copy',
                       ),
                     ),
-                    Text(
-                      description,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.titleMedium,
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                                fontWeight: FontWeight.bold,
+                                color: CVTheme.textColor(context),
+                              ),
+                        ),
+                        Text(
+                          description,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                      ],
                     ),
                   ],
                 ),


### PR DESCRIPTION
Fixes #

Describe the changes you have made in this PR -

In this pull request, I have implemented a new feature that allows users to copy links from the application with ease. The copy button allows users to copy any links generated in the app and use them externally. The code changes that have been made for this feature improves UX by making link sharing easier for users. This feature was also tested for dependability within the app environment.

Screenshots of the changes (If any) -


<img width="694" alt="Screenshot 2025-04-01 at 4 44 26 PM" src="https://github.com/user-attachments/assets/dfc241c3-20c3-4973-9fac-b8615edb5d95" />

<img width="597" alt="Screenshot 2025-04-01 at 4 50 31 PM" src="https://github.com/user-attachments/assets/c0f38248-3e96-4425-aade-764e2b7947f9" />


Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a copy URL button on the social card. When pressed, the URL is copied to your clipboard, and you receive a confirmation notification.
  
- **Style**
  - Improved the layout with increased spacing between the image and text, enhancing the overall visual presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->