### PR TITLE
Fallback email/URL mechanism and sms intent

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,25 +7,7 @@
          FlutterApplication and put your custom class here. -->
 
     <!-- Queries section needed for Android 11+ to handle mailto and other URLs -->
-    <queries>
-        <!-- For mailto: links -->
-        <intent>
-            <action android:name="android.intent.action.VIEW" />
-            <data android:scheme="mailto" />
-        </intent>
-        
-        <!-- For https: links -->
-        <intent>
-            <action android:name="android.intent.action.VIEW" />
-            <data android:scheme="https" />
-        </intent>
-        
-        <!-- For tel: links -->
-        <intent>
-            <action android:name="android.intent.action.DIAL" />
-            <data android:scheme="tel" />
-        </intent>
-    </queries>
+
 
     <!-- Permissions -->
     <uses-permission android:name="android.permission.INTERNET" />
@@ -38,13 +20,17 @@
                 <data android:scheme="mailto" />
             </intent>
             <intent>
-            <action android:name="android.intent.action.VIEW" />
-            <data android:scheme="tel" />
-        </intent>
-        <intent>
-            <action android:name="android.intent.action.VIEW" />
-            <data android:scheme="sms" />
-        </intent>
+                <action android:name="android.intent.action.VIEW" />
+                <data android:scheme="tel" />
+            </intent>
+            <intent>
+                <action android:name="android.intent.action.VIEW" />
+                <data android:scheme="sms" />
+            </intent>
+            <intent>
+                <action android:name="android.intent.action.VIEW" />
+                <data android:scheme="https" />
+            </intent>
         </queries>
     <application
         android:name="${applicationName}"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,13 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <queries>
+            <!-- To support mailto URLs -->
+            <intent>
+                <action android:name="android.intent.action.VIEW" />
+                <data android:scheme="mailto" />
+            </intent>
+        </queries>
     <application
         android:name="${applicationName}"
         android:label="CircuitVerse"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,33 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
+
+     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
+
+    <!-- Queries section needed for Android 11+ to handle mailto and other URLs -->
+    <queries>
+        <!-- For mailto: links -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="mailto" />
+        </intent>
+        
+        <!-- For https: links -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+        
+        <!-- For tel: links -->
+        <intent>
+            <action android:name="android.intent.action.DIAL" />
+            <data android:scheme="tel" />
+        </intent>
+    </queries>
+
+    <!-- Permissions -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
@@ -27,6 +51,8 @@
         android:label="CircuitVerse"
         android:requestLegacyExternalStorage="true"
         android:icon="@mipmap/launcher_icon">
+        
+        <!-- Main Activity -->
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"
@@ -39,21 +65,24 @@
             <!-- until Flutter renders its first frame. -->
             <!-- Theme to apply as soon as Flutter begins rendering frames -->
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+
+        <!-- Flutter embedding meta-data -->
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
-        
+
         <!-- Facebook authentication configuration -->
         <meta-data
             android:name="com.facebook.sdk.ApplicationId"
             android:value="@string/facebook_app_id" />
-        <activity android:name="com.facebook.FacebookActivity"
+        <activity
+            android:name="com.facebook.FacebookActivity"
             android:exported="true"
             android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
             android:label="@string/app_name" />
@@ -67,6 +96,7 @@
                 <data android:scheme="@string/fb_login_protocol_scheme" />
             </intent-filter>
         </activity>
+
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"
             android:exported="true"
@@ -74,9 +104,9 @@
             android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
 
         <!-- Github authentication configuration -->
-        <activity 
+        <activity
             android:name="com.linusu.flutter_web_auth.CallbackActivity"
-            android:exported="true" >
+            android:exported="true">
             <intent-filter android:label="flutter_web_auth">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -84,5 +114,6 @@
                 <data android:scheme="circuitverse" />
             </intent-filter>
         </activity>
+
     </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,14 @@
                 <action android:name="android.intent.action.VIEW" />
                 <data android:scheme="mailto" />
             </intent>
+            <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="tel" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="sms" />
+        </intent>
         </queries>
     <application
         android:name="${applicationName}"

--- a/lib/ui/components/cv_social_card.dart
+++ b/lib/ui/components/cv_social_card.dart
@@ -20,7 +20,7 @@ class CircuitVerseSocialCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () async {
-        launchURL(url);
+        launchURL(context,url);
       },
       child: Card(
         color:

--- a/lib/ui/components/cv_social_card.dart
+++ b/lib/ui/components/cv_social_card.dart
@@ -20,7 +20,7 @@ class CircuitVerseSocialCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () async {
-        launchURL(context,url);
+        launchURL(context, url);
       },
       child: Card(
         color:

--- a/lib/ui/views/about/components/contributor_avatar.dart
+++ b/lib/ui/views/about/components/contributor_avatar.dart
@@ -12,7 +12,7 @@ class ContributorAvatar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () => launchURL(contributor.htmlUrl),
+      onTap: () => launchURL(context,contributor.htmlUrl),
       child: Tooltip(
         message: contributor.login,
         child: Container(

--- a/lib/ui/views/about/components/contributor_avatar.dart
+++ b/lib/ui/views/about/components/contributor_avatar.dart
@@ -12,7 +12,7 @@ class ContributorAvatar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () => launchURL(context,contributor.htmlUrl),
+      onTap: () => launchURL(context, contributor.htmlUrl),
       child: Tooltip(
         message: contributor.login,
         child: Container(

--- a/lib/ui/views/contributors/components/contributors_donate_card.dart
+++ b/lib/ui/views/contributors/components/contributors_donate_card.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_app/utils/url_launcher.dart';
-
 class ContributeDonateCard extends StatelessWidget {
   const ContributeDonateCard({
     super.key,
@@ -21,7 +20,7 @@ class ContributeDonateCard extends StatelessWidget {
         const SizedBox(height: 10),
         GestureDetector(
           onTap: () async {
-            launchURL(url);
+            launchURL(context,url);
           },
           child: Container(
             decoration: BoxDecoration(

--- a/lib/ui/views/contributors/components/contributors_donate_card.dart
+++ b/lib/ui/views/contributors/components/contributors_donate_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_app/utils/url_launcher.dart';
+
 class ContributeDonateCard extends StatelessWidget {
   const ContributeDonateCard({
     super.key,
@@ -20,7 +21,7 @@ class ContributeDonateCard extends StatelessWidget {
         const SizedBox(height: 10),
         GestureDetector(
           onTap: () async {
-            launchURL(context,url);
+            launchURL(context, url);
           },
           child: Container(
             decoration: BoxDecoration(

--- a/lib/ui/views/ib/ib_page_view.dart
+++ b/lib/ui/views/ib/ib_page_view.dart
@@ -128,7 +128,7 @@ class _IbPageViewState extends State<IbPageView> {
       } else {
         // Try to navigate to another page using url
         // (TODO) We need [IbLandingViewModel] to be able to get Chapter using [httpUrl]
-        launchURL(href);
+        launchURL(context,href);
       }
     }
 

--- a/lib/ui/views/ib/ib_page_view.dart
+++ b/lib/ui/views/ib/ib_page_view.dart
@@ -128,7 +128,7 @@ class _IbPageViewState extends State<IbPageView> {
       } else {
         // Try to navigate to another page using url
         // (TODO) We need [IbLandingViewModel] to be able to get Chapter using [httpUrl]
-        launchURL(context,href);
+        launchURL(context, href);
       }
     }
 

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -35,6 +35,24 @@ Future<void> launchURL(
     );
   }
 
+  void showFallbackDialog(BuildContext context, String message) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text("Notification"),
+          content: Text(message),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text("OK"),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   if (url.startsWith('mailto:')) {
     final Uri uri = Uri.parse(url);
     if (await canLaunchUrl(uri)) {
@@ -70,24 +88,35 @@ Future<void> launchURL(
       await launchUrlString(url, mode: LaunchMode.externalApplication);
     } else if (retryCount < maxRetryAttempts) {
       Clipboard.setData(ClipboardData(text: url));
-      showCustomSnackBar(
-        message: "Couldn't open $url. Copied to clipboard.",
-        backgroundColor: Colors.redAccent,
-        duration: const Duration(seconds: 2),
-        action: SnackBarAction(
-          label: "Retry",
-          textColor: Colors.white,
-          onPressed: () async {
-            await launchURL(context, url, retryCount: retryCount + 1);
-          },
-        ),
-      );
+      if (ScaffoldMessenger.of(context).mounted) {
+        showCustomSnackBar(
+          message: "Couldn't open $url. Copied to clipboard.",
+          backgroundColor: Colors.redAccent,
+          duration: const Duration(seconds: 2),
+          action: SnackBarAction(
+            label: "Retry",
+            textColor: Colors.white,
+            onPressed: () async {
+              await launchURL(context, url, retryCount: retryCount + 1);
+            },
+          ),
+        );
+      } else {
+        showFallbackDialog(context, "Failed to open the URL");
+      }
     } else {
-      showCustomSnackBar(
-        message: "Failed to open the URL after several attempts.",
-        backgroundColor: Colors.redAccent,
-        duration: const Duration(seconds: 2),
-      );
+      if (ScaffoldMessenger.of(context).mounted) {
+        showCustomSnackBar(
+          message: "Failed to open the URL after several attempts.",
+          backgroundColor: Colors.redAccent,
+          duration: const Duration(seconds: 2),
+        );
+      } else {
+        showFallbackDialog(
+          context,
+          "Failed to open the URL after several attempts.",
+        );
+      }
     }
   }
 }

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -39,6 +39,32 @@ Future<void> launchURL(
         mode: LaunchMode.externalApplication,
       );
     }
+  } else if (url.startsWith('sms:')) {
+    final Uri smsUri = Uri.parse(url);
+    if (await canLaunchUrl(smsUri)) {
+      await launchUrl(smsUri, mode: LaunchMode.externalApplication);
+    } else {
+      final phone = url.replaceFirst('sms:', '');
+      Clipboard.setData(ClipboardData(text: phone));
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            "Error, Phone no copied to clipboard: $phone",
+            style: const TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          backgroundColor: Colors.grey[800],
+          behavior: SnackBarBehavior.floating,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10),
+          ),
+          duration: const Duration(seconds: 1),
+          margin: const EdgeInsets.all(16),
+        ),
+      );
+    }
   } else {
     if (await canLaunchUrlString(url)) {
       await launchUrlString(url);

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -1,9 +1,34 @@
 import 'package:url_launcher/url_launcher_string.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/material.dart';
 
-void launchURL(String url) async {
-  if (await canLaunchUrlString(url)) {
-    await launchUrlString(url);
+void launchURL(BuildContext context,String url) async {
+  if (url.startsWith('mailto:')) {
+    final Uri uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(
+        uri,
+        mode: LaunchMode.externalApplication,
+      );
+    } else {
+      final email = url.replaceFirst('mailto:', '');
+      Clipboard.setData(ClipboardData(text: email));
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text("Email copied to clipboard: $email"),
+          duration: Duration(seconds: 1),
+        ),
+      );
+      await Future.delayed(Duration(seconds: 1));
+      await launchUrlString(
+        'https://mail.google.com/mail/u/0/?fs=1&to=$email&tf=cm',
+        mode: LaunchMode.externalApplication,
+      );
+    }
   } else {
-    throw 'Could not launch $url';
+    if (await canLaunchUrlString(url)) {
+      await launchUrlString(url);
+    } 
   }
 }

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -65,10 +65,12 @@ Future<void> launchURL(
         backgroundColor: Colors.grey.shade800,
         duration: const Duration(seconds: 2),
       );
-      await launchUrlString(
-        'https://mail.google.com/mail/u/0/?fs=1&to=$email&tf=cm',
-        mode: LaunchMode.externalApplication,
-      );
+      final emailurl = 'https://mail.google.com/mail/u/0/?fs=1&to=$email&tf=cm';
+      if (await canLaunchUrlString(emailurl)) {
+        await launchUrlString(emailurl, mode: LaunchMode.externalApplication);
+      } else {
+        showFallbackDialog(context, "Failed to open the email client");
+      }
     }
   } else if (url.startsWith('sms:')) {
     final Uri smsUri = Uri.parse(url);

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -17,10 +17,7 @@ Future<void> launchURL(
       final email = url.replaceFirst('mailto:', '');
       Clipboard.setData(ClipboardData(text: email));
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text("Email copied to clipboard: $email"),
-          // duration: Duration(seconds: 1),
-        ),
+        SnackBar(content: Text("Email copied to clipboard: $email")),
       );
       await launchUrlString(
         'https://mail.google.com/mail/u/0/?fs=1&to=$email&tf=cm',

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -3,7 +3,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 
-void launchURL(BuildContext context, String url) async {
+Future<void> launchURL(BuildContext context, String url) async {
   if (url.startsWith('mailto:')) {
     final Uri uri = Uri.parse(url);
     if (await canLaunchUrl(uri)) {

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -18,8 +18,20 @@ Future<void> launchURL(
       Clipboard.setData(ClipboardData(text: email));
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text("Email copied to clipboard: $email"),
-          duration: Duration(seconds: 1),
+          content: Text(
+            "Email copied to clipboard: $email",
+            style: const TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          backgroundColor: Colors.grey[800],
+          behavior: SnackBarBehavior.floating,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10),
+          ),
+          duration: const Duration(seconds: 1),
+          margin: const EdgeInsets.all(16),
         ),
       );
       await launchUrlString(

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -3,14 +3,11 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 
-void launchURL(BuildContext context,String url) async {
+void launchURL(BuildContext context, String url) async {
   if (url.startsWith('mailto:')) {
     final Uri uri = Uri.parse(url);
     if (await canLaunchUrl(uri)) {
-      await launchUrl(
-        uri,
-        mode: LaunchMode.externalApplication,
-      );
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
     } else {
       final email = url.replaceFirst('mailto:', '');
       Clipboard.setData(ClipboardData(text: email));
@@ -29,6 +26,6 @@ void launchURL(BuildContext context,String url) async {
   } else {
     if (await canLaunchUrlString(url)) {
       await launchUrlString(url);
-    } 
+    }
   }
 }

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -62,7 +62,7 @@ Future<void> launchURL(
       showCustomSnackBar(
         message: "Phone number copied to clipboard: $phone",
         backgroundColor: Colors.grey.shade800,
-        duration: const Duration(seconds: 1),
+        duration: const Duration(seconds: 2),
       );
     }
   } else {

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -19,7 +19,7 @@ Future<void> launchURL(
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text("Email copied to clipboard: $email"),
-          duration: Duration(seconds: 1),
+          // duration: Duration(seconds: 1),
         ),
       );
       await launchUrlString(
@@ -31,10 +31,11 @@ Future<void> launchURL(
     if (await canLaunchUrlString(url)) {
       await launchUrlString(url);
     } else if (retryCount < maxRetryAttempts) {
+      Clipboard.setData(ClipboardData(text: url));
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            "Failed to open the URL: $url",
+            "Couldn't open $url. Copied to clipboard.",
             style: const TextStyle(
               color: Colors.white,
               fontWeight: FontWeight.bold,

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -9,6 +9,32 @@ Future<void> launchURL(
   int retryCount = 0,
 }) async {
   const int maxRetryAttempts = 2;
+
+  void showCustomSnackBar({
+    required String message,
+    Color backgroundColor = Colors.grey,
+    Duration duration = const Duration(seconds: 2),
+    SnackBarAction? action,
+  }) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          message,
+          style: const TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        backgroundColor: backgroundColor,
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+        duration: duration,
+        margin: const EdgeInsets.all(16),
+        action: action,
+      ),
+    );
+  }
+
   if (url.startsWith('mailto:')) {
     final Uri uri = Uri.parse(url);
     if (await canLaunchUrl(uri)) {
@@ -16,23 +42,10 @@ Future<void> launchURL(
     } else {
       final email = url.replaceFirst('mailto:', '');
       Clipboard.setData(ClipboardData(text: email));
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            "Email copied to clipboard: $email",
-            style: const TextStyle(
-              color: Colors.white,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-          backgroundColor: Colors.grey[800],
-          behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(10),
-          ),
-          duration: const Duration(seconds: 1),
-          margin: const EdgeInsets.all(16),
-        ),
+      showCustomSnackBar(
+        message: "Email copied to clipboard: $email",
+        backgroundColor: Colors.grey.shade800,
+        duration: const Duration(seconds: 2),
       );
       await launchUrlString(
         'https://mail.google.com/mail/u/0/?fs=1&to=$email&tf=cm',
@@ -46,70 +59,34 @@ Future<void> launchURL(
     } else {
       final phone = url.replaceFirst('sms:', '');
       Clipboard.setData(ClipboardData(text: phone));
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            "Error, Phone no copied to clipboard: $phone",
-            style: const TextStyle(
-              color: Colors.white,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-          backgroundColor: Colors.grey[800],
-          behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(10),
-          ),
-          duration: const Duration(seconds: 1),
-          margin: const EdgeInsets.all(16),
-        ),
+      showCustomSnackBar(
+        message: "Phone number copied to clipboard: $phone",
+        backgroundColor: Colors.grey.shade800,
+        duration: const Duration(seconds: 1),
       );
     }
   } else {
     if (await canLaunchUrlString(url)) {
-      await launchUrlString(url);
+      await launchUrlString(url, mode: LaunchMode.externalApplication);
     } else if (retryCount < maxRetryAttempts) {
       Clipboard.setData(ClipboardData(text: url));
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            "Couldn't open $url. Copied to clipboard.",
-            style: const TextStyle(
-              color: Colors.white,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-          backgroundColor: Colors.redAccent,
-          behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(10),
-          ),
-          duration: const Duration(seconds: 2),
-          margin: const EdgeInsets.all(16),
-          action: SnackBarAction(
-            label: "Retry",
-            textColor: Colors.white,
-            onPressed: () async {
-              await launchURL(context, url, retryCount: retryCount + 1);
-            },
-          ),
+      showCustomSnackBar(
+        message: "Couldn't open $url. Copied to clipboard.",
+        backgroundColor: Colors.redAccent,
+        duration: const Duration(seconds: 2),
+        action: SnackBarAction(
+          label: "Retry",
+          textColor: Colors.white,
+          onPressed: () async {
+            await launchURL(context, url, retryCount: retryCount + 1);
+          },
         ),
       );
     } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            "Failed to open the URL after several attempts.",
-            style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
-          ),
-          backgroundColor: Colors.redAccent,
-          behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(10),
-          ),
-          duration: Duration(seconds: 2),
-          margin: EdgeInsets.all(16),
-        ),
+      showCustomSnackBar(
+        message: "Failed to open the URL after several attempts.",
+        backgroundColor: Colors.redAccent,
+        duration: const Duration(seconds: 2),
       );
     }
   }

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -3,7 +3,12 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 
-Future<void> launchURL(BuildContext context, String url) async {
+Future<void> launchURL(
+  BuildContext context,
+  String url, {
+  int retryCount = 0,
+}) async {
+  const int maxRetryAttempts = 2;
   if (url.startsWith('mailto:')) {
     final Uri uri = Uri.parse(url);
     if (await canLaunchUrl(uri)) {
@@ -25,7 +30,7 @@ Future<void> launchURL(BuildContext context, String url) async {
   } else {
     if (await canLaunchUrlString(url)) {
       await launchUrlString(url);
-    } else {
+    } else if (retryCount < maxRetryAttempts) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
@@ -46,9 +51,25 @@ Future<void> launchURL(BuildContext context, String url) async {
             label: "Retry",
             textColor: Colors.white,
             onPressed: () async {
-              await launchURL(context, url);
+              await launchURL(context, url, retryCount: retryCount + 1);
             },
           ),
+        ),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            "Failed to open the URL after several attempts.",
+            style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+          ),
+          backgroundColor: Colors.redAccent,
+          behavior: SnackBarBehavior.floating,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10),
+          ),
+          duration: Duration(seconds: 2),
+          margin: EdgeInsets.all(16),
         ),
       );
     }

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -45,7 +45,7 @@ Future<void> launchURL(BuildContext context, String url) async {
           action: SnackBarAction(
             label: "Retry",
             textColor: Colors.white,
-            onPressed: () async{
+            onPressed: () async {
               await launchURL(context, url);
             },
           ),

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -17,7 +17,10 @@ Future<void> launchURL(
       final email = url.replaceFirst('mailto:', '');
       Clipboard.setData(ClipboardData(text: email));
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text("Email copied to clipboard: $email")),
+        SnackBar(
+          content: Text("Email copied to clipboard: $email"),
+          duration: Duration(seconds: 1),
+        ),
       );
       await launchUrlString(
         'https://mail.google.com/mail/u/0/?fs=1&to=$email&tf=cm',

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -17,7 +17,6 @@ Future<void> launchURL(BuildContext context, String url) async {
           duration: Duration(seconds: 1),
         ),
       );
-      await Future.delayed(Duration(seconds: 1));
       await launchUrlString(
         'https://mail.google.com/mail/u/0/?fs=1&to=$email&tf=cm',
         mode: LaunchMode.externalApplication,
@@ -26,6 +25,32 @@ Future<void> launchURL(BuildContext context, String url) async {
   } else {
     if (await canLaunchUrlString(url)) {
       await launchUrlString(url);
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            "Failed to open the URL: $url",
+            style: const TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          backgroundColor: Colors.redAccent,
+          behavior: SnackBarBehavior.floating,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10),
+          ),
+          duration: const Duration(seconds: 2),
+          margin: const EdgeInsets.all(16),
+          action: SnackBarAction(
+            label: "Retry",
+            textColor: Colors.white,
+            onPressed: () async{
+              await launchURL(context, url);
+            },
+          ),
+        ),
+      );
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,7 +58,7 @@ dependencies:
   theme_provider: ^0.6.0
   timeago: ^3.1.0
   transparent_image: ^2.0.0
-  url_launcher: ^6.0.18
+  url_launcher: ^6.3.0
   flutter_facebook_auth: ^6.0.4
 
   http: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   datetime_picker_formfield: ^2.0.0
   flutter:
     sdk: flutter
+  
   flutter_inappwebview: ^6.1.5
   # flutter_facebook_auth: ^5.0.6
   flutter_html: ^3.0.0-alpha.6


### PR DESCRIPTION
Fixes #

Describe the changes you have made in this PR -

Introduced a fallback method for email links: If the email link (mailto) is not working on Android, it opens Gmail in Chrome so that users can send emails to the organization. Integrated a copy feature for the email: When the email link can’t be accessed, the address gets copied, and the user is notified.

**Also added the SMS Intent** in the intent so that it can come in handy in the future if someone wants to use the SMS directly in the application

**Also added the retry mechanism** that if the URL fails to open then it should be copied into the clipboard and also a popup should open for retrying to open that url


NOTE:-

Upgraded the url_launcher to the latest version and the positions of the intents (not causing any error)

Screenshots of the changes (If any) -

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Improved external link handling across the app for more context-aware navigation.
	- Enhanced support for phone links on Android, added SMS handling, and refined email link behavior with user notifications and fallback options.
- **Chores**
	- Upgraded a core URL-launch dependency to version 6.3.0 for improved performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->