### PR TITLE
added the copy button on the chips

### DIFF
--- a/lib/ui/components/cv_social_card.dart
+++ b/lib/ui/components/cv_social_card.dart
@@ -40,19 +40,34 @@ class CircuitVerseSocialCard extends StatelessWidget {
                   children: [
                     Positioned(
                       top: 0,
-                      right: -4,
+                      right: 0,
                       child: IconButton(
-                        onPressed: () {
-                          Clipboard.setData(ClipboardData(text: url));
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(
-                              content: const Text('Copied to clipboard!'),
-                              duration: const Duration(seconds: 2),
-                              behavior: SnackBarBehavior.floating,
-                            ),
-                          );
+                        onPressed: () async {
+                          try {
+                            await Clipboard.setData(ClipboardData(text: url));
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text('Copied to clipboard!'),
+                                duration: Duration(seconds: 2),
+                                behavior: SnackBarBehavior.floating,
+                              ),
+                            );
+                          } catch (error) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text('Failed to copy to clipboard.'),
+                                duration: Duration(seconds: 2),
+                                behavior: SnackBarBehavior.floating,
+                              ),
+                            );
+                          }
                         },
-                        icon: Icon(Icons.copy),
+                        icon: Icon(
+                          Icons.copy,
+                          color: Theme.of(context).iconTheme.color,
+                        ),
+                        splashColor: Theme.of(context).splashColor,
+                        highlightColor: Theme.of(context).highlightColor,
                         tooltip: 'Copy',
                       ),
                     ),

--- a/lib/ui/components/cv_social_card.dart
+++ b/lib/ui/components/cv_social_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_app/cv_theme.dart';
 import 'package:mobile_app/utils/url_launcher.dart';
+import 'package:flutter/services.dart';
 
 class CircuitVerseSocialCard extends StatelessWidget {
   const CircuitVerseSocialCard({
@@ -33,25 +34,49 @@ class CircuitVerseSocialCard extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.start,
             children: <Widget>[
               Image.asset(imagePath, width: 48),
-              const SizedBox(width: 16),
+              const SizedBox(width: 20),
               Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Text(
-                      title,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold,
-                        color: CVTheme.textColor(context),
+                child: Stack(
+                  children: [
+                    Positioned(
+                      top: 0,
+                      right: -4,
+                      child: IconButton(
+                        onPressed: () {
+                          Clipboard.setData(ClipboardData(text: url));
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: const Text('Copied to clipboard!'),
+                              duration: const Duration(seconds: 2),
+                              behavior: SnackBarBehavior.floating,
+                            ),
+                          );
+                        },
+                        icon: Icon(Icons.copy),
+                        tooltip: 'Copy',
                       ),
                     ),
-                    Text(
-                      description,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.titleMedium,
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(
+                            context,
+                          ).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: CVTheme.textColor(context),
+                          ),
+                        ),
+                        Text(
+                          description,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                      ],
                     ),
                   ],
                 ),


### PR DESCRIPTION
Fixes #

Describe the changes you have made in this PR -

In this pull request, I have implemented a new feature that allows users to copy links from the application with ease. The copy button allows users to copy any links generated in the app and use them externally. The code changes that have been made for this feature improves UX by making link sharing easier for users. This feature was also tested for dependability within the app environment.

Screenshots of the changes (If any) -

<img width="597" alt="Screenshot 2025-04-01 at 4 50 31 PM" src="https://github.com/user-attachments/assets/6d04eb7d-69b5-4caa-84a7-4071534255ab" />
<img width="694" alt="Screenshot 2025-04-01 at 4 44 26 PM" src="https://github.com/user-attachments/assets/933d8302-1002-4d21-9a7d-a20be69ac62f" />


Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a button on the social card that lets users copy the URL for easier sharing.
  - Provides a confirmation message when the URL is copied.

- **Style**
  - Adjusted the layout and spacing of the card for a cleaner, more balanced presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->