### PR TITLE
added loading state and spinners for notifications,profile sections

### DIFF
--- a/lib/ui/views/notifications/notifications_view.dart
+++ b/lib/ui/views/notifications/notifications_view.dart
@@ -74,6 +74,21 @@ class NotificationsView extends StatelessWidget {
           context.read<CVLandingViewModel>().hasPendingNotif = model.hasUnread;
         });
 
+        if (model.isBusy(model.FETCH_NOTIFICATIONS)) {
+          return const Column(
+            children: [
+              SizedBox(height: 200),
+              Center(
+                child: SizedBox(
+                  width: 40,
+                  height: 40,
+                  child: CircularProgressIndicator(strokeWidth: 3),
+                ),
+              ),
+            ],
+          );
+        }
+
         final hasNoNotifications = model.notifications.isEmpty;
         final hasNoUnread =
             !hasNoNotifications &&

--- a/lib/ui/views/profile/user_favourites_view.dart
+++ b/lib/ui/views/profile/user_favourites_view.dart
@@ -79,6 +79,21 @@ class _UserFavouritesViewState extends State<UserFavouritesView>
         });
       },
       builder: (context, model, child) {
+        if (model.isBusy(model.FETCH_USER_FAVOURITES)) {
+          return const Column(
+            children: [
+              SizedBox(height: 120),
+              Center(
+                child: SizedBox(
+                  width: 40,
+                  height: 40,
+                  child: CircularProgressIndicator(strokeWidth: 3),
+                ),
+              ),
+            ],
+          );
+        }
+
         final _items = <Widget>[];
 
         if (model.isSuccess(model.FETCH_USER_FAVOURITES)) {

--- a/lib/ui/views/profile/user_projects_view.dart
+++ b/lib/ui/views/profile/user_projects_view.dart
@@ -80,6 +80,21 @@ class _UserProjectsViewState extends State<UserProjectsView>
       builder: (context, model, child) {
         final _items = <Widget>[];
 
+        if (model.isBusy(model.FETCH_USER_PROJECTS)) {
+          return const Column(
+            children: [
+              SizedBox(height: 120),
+              Center(
+                child: SizedBox(
+                  width: 40,
+                  height: 40,
+                  child: CircularProgressIndicator(strokeWidth: 3),
+                ),
+              ),
+            ],
+          );
+        }
+
         if (model.isSuccess(model.FETCH_USER_PROJECTS)) {
           if (model.userProjects.isEmpty) {
             _items.add(_emptyState());


### PR DESCRIPTION


Fixes #320 

Describe the changes you have made in this PR -

Added loading state and spinner for Notifications, Projects, and Favorites

Fixed the issue where these sections showed a blank screen while fetching data

Screenshots of the changes (If any) -
![image](https://github.com/user-attachments/assets/1948730f-7c5d-4f55-a69e-8c355a03a329)
![image](https://github.com/user-attachments/assets/67f566e5-ed38-477c-b811-e0f03ee933e8)


Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added visual loading indicators across notifications, user favourites, and user projects views to provide clear feedback during data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->