### PR TITLE
feat: Add button to open circuit in browser from ProjectDetailsView

### DIFF
--- a/lib/ui/views/projects/project_details_view.dart
+++ b/lib/ui/views/projects/project_details_view.dart
@@ -1,3 +1,4 @@
+import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
@@ -31,6 +32,16 @@ class ProjectDetailsView extends StatefulWidget {
 }
 
 class _ProjectDetailsViewState extends State<ProjectDetailsView> {
+  void _launchProjectURL(String url) async {
+  final uri = Uri.parse(url);
+  if (await canLaunchUrl(uri)) {
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  } else {
+    // Optional: Display a snackbar or toast instead
+    print('Could not launch $url');
+  }
+}
+
   final DialogService _dialogService = locator<DialogService>();
   late ProjectDetailsViewModel _model;
   final _formKey = GlobalKey<FormState>();


### PR DESCRIPTION
Fixes #

Describe the changes you have made in this PR -Added a new "Open in Browser" button to the ProjectDetailsView screen in the CircuitVerse mobile app.
This button uses the url_launcher package to open the corresponding circuit in the default browser with the URL:
https://circuitverse.org/simulator/edit/{project.id}
Screenshots of the changes (If any) -
Not available as Flutter environment is not set up locally.
Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled direct opening of project URLs from the project details view, allowing seamless navigation to external applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->