### PR TITLE
improve text contrast for inactive tabs in dark mode

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -57,6 +57,7 @@ if (releaseKeystorePropertiesFile.exists()) {
 android {
     compileSdkVersion 35
     namespace 'org.circuitverse.mobile_app'
+    ndkVersion = "28.0.13004108"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/lib/ui/views/profile/profile_view.dart
+++ b/lib/ui/views/profile/profile_view.dart
@@ -173,7 +173,7 @@ class _ProfileViewState extends State<ProfileView> {
               color: CVTheme.lightGrey.withValues(alpha: 0.2),
               tabBar: const TabBar(
                 labelColor: Colors.white,
-                unselectedLabelColor: Colors.black87,
+                unselectedLabelColor: Colors.white,
                 indicatorSize: TabBarIndicatorSize.tab,
                 indicator: BoxDecoration(
                   color: CVTheme.primaryColor,


### PR DESCRIPTION

Description:
This PR resolves a UI issue where the text on inactive tabs in the profile section was difficult to read when dark mode was enabled.

Bug Description:
In dark mode, inactive tab labels (e.g., "Circuits") had insufficient contrast against the background.

This made it hard for users to distinguish between active and inactive tabs.

Fix Summary:
Updated the text color/style of inactive tabs in dark mode to ensure sufficient contrast.

The fix enhances readability and improves accessibility for users using dark mode.

Steps to Reproduce (before fix):
Go to the Profile page in dark mode.

Click on an inactive tab (e.g., "Circuits").

Observe that the tab label is barely visible due to low contrast.

Expected Behavior (after fix):
Inactive tab text is clearly visible with appropriate contrast in dark mode.

UI consistency and accessibility are improved.

Screenshots (Optional):

![WhatsApp Image 2025-05-25 at 23 57 48_99dfad61](https://github.com/user-attachments/assets/9549c77b-fc6d-42b7-be17-b7887b03ec7d)

