### PR TITLE
improve text contrast for inactive tabs in dark mode

### DIFF
--- a/lib/ui/views/profile/profile_view.dart
+++ b/lib/ui/views/profile/profile_view.dart
@@ -173,7 +173,7 @@ class _ProfileViewState extends State<ProfileView> {
               color: CVTheme.lightGrey.withValues(alpha: 0.2),
               tabBar: const TabBar(
                 labelColor: Colors.white,
-                unselectedLabelColor: Colors.black87,
+                unselectedLabelColor: Colors.white,
                 indicatorSize: TabBarIndicatorSize.tab,
                 indicator: BoxDecoration(
                   color: CVTheme.primaryColor,


### PR DESCRIPTION
Describe the bug
In dark mode, the text on inactive tabs (e.g., "Circuits") within the profile screen has insufficient contrast, making it difficult to read.

To Reproduce
Steps to reproduce the behavior:

Switch to dark mode.

Navigate to the profile screen.

Click on any inactive tab (like "Circuits").

Observe that the inactive tab's text is hard to read due to low contrast.

Expected behavior
The inactive tab text should maintain sufficient contrast against the dark background to ensure readability.

[Dark Mode UI Issue] Inactive Tab Text Lacks Contrast and is Difficult to Read #317

Describe the changes you have made in this PR

Updated the unselectedLabelColor in lib/ui/views/profile/profile_view.dart from Colors.black87 to Colors.white to ensure better text visibility in dark mode.

Screenshots    
after changes
![WhatsApp Image 2025-05-25 at 23 57 48_5dced0dc](https://github.com/user-attachments/assets/986da37e-310f-4837-ae12-6715a6617393)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the color of unselected tab labels in the profile view for improved visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->