### PR TITLE
Upgrade AGP to 8.5.0 and Gradle to 8.7 for Kotlin 2.1.10 compatibility

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.2.1" apply false
+    id "com.android.application" version "8.5.0" apply false
     id "org.jetbrains.kotlin.android" version "2.1.10" apply false
 }
 


### PR DESCRIPTION
# **Fixes** #423 

### Describe the changes you have made in this PR
- Upgraded **Android Gradle Plugin** from `8.2.1` → `8.5.0`
- Updated **Gradle Wrapper** from `8.5` → `8.7` to meet AGP 8.5.0 requirements
- Ensured **Kotlin version** is set to `2.1.10` for compatibility with updated dependencies
- Resolved AGP deprecation warning in Flutter and Kotlin metadata version mismatch errors

### Screenshots of the changes (If any)
N/A

---

**Note:** Please check **Allow edits from maintainers** if you would like us to assist in the PR.
