### PR TITLE
Revert "chore(deps):(deps): bump get_it from 8.0.3 to 8.2.0"

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -646,10 +646,10 @@ packages:
     dependency: "direct main"
     description:
       name: get_it
-      sha256: a4292e7cf67193f8e7c1258203104eb2a51ec8b3a04baa14695f4064c144297b
+      sha256: f126a3e286b7f5b578bf436d5592968706c4c1de28a228b870ce375d9f743103
       url: "https://pub.dev"
     source: hosted
-    version: "8.2.0"
+    version: "8.0.3"
   glob:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   flutter_typeahead: ^5.2.0
   fluttericon: ^2.0.0
   get: ^4.6.1
-  get_it: ^8.2.0
+  get_it: ^8.0.3
   google_sign_in: ^6.3.0
   hive: ^2.0.4
   hive_flutter: ^1.1.0


### PR DESCRIPTION
Reverts CircuitVerse/mobile-app#418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated a dependency version constraint to broaden compatibility with older 8.x releases while maintaining stability.
  - Improves dependency resolution and build consistency across environments.
  - No functional or behavioral changes to the app; existing features continue to work as before.
  - This maintenance update helps prevent version conflicts in projects with varied dependency requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->