### PR TITLE
Migrate share_plus to v11.1.0 and update sharing implementation

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -51,7 +51,7 @@ if (releaseKeystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion 35
+    compileSdk 35
     namespace 'org.circuitverse.mobile_app'
 
     compileOptions {
@@ -67,7 +67,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
 
-    lintOptions {
+    lint {
         disable 'InvalidPackage'
     }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.2.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.10" apply false
+    id "com.android.application" version "8.7.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.25" apply false
 }
 
 include ":app"

--- a/lib/ui/views/projects/components/featured_project_card.dart
+++ b/lib/ui/views/projects/components/featured_project_card.dart
@@ -108,7 +108,7 @@ class _FeaturedProjectCardState extends State<FeaturedProjectCard> {
     final projectUrl = _getProjectUrl();
 
     try {
-      await Share.share(projectUrl);
+      await SharePlus.instance.share(ShareParams(text: projectUrl));
     } catch (e) {
       debugPrint('Error sharing project: $e');
     }

--- a/lib/ui/views/projects/components/featured_project_card.dart
+++ b/lib/ui/views/projects/components/featured_project_card.dart
@@ -108,7 +108,13 @@ class _FeaturedProjectCardState extends State<FeaturedProjectCard> {
     final projectUrl = _getProjectUrl();
 
     try {
-      await SharePlus.instance.share(ShareParams(text: projectUrl));
+      final box = context.findRenderObject() as RenderBox?;
+      await SharePlus.instance.share(
+        ShareParams(
+          text: projectUrl,
+          sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
+        ),
+      );
     } catch (e) {
       debugPrint('Error sharing project: $e');
     }

--- a/lib/ui/views/projects/project_details_view.dart
+++ b/lib/ui/views/projects/project_details_view.dart
@@ -52,9 +52,12 @@ class _ProjectDetailsViewState extends State<ProjectDetailsView> {
 
   void onShareButtonPressed() {
     final RenderBox? box = context.findRenderObject() as RenderBox?;
-    Share.share(
-      _getProjectUrl(),
-      sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
+
+    SharePlus.instance.share(
+      ShareParams(
+        text: _getProjectUrl(),
+        sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
+      ),
     );
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1303,18 +1303,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      sha256: d7dc0630a923883c6328ca31b89aa682bacbf2f8304162d29f7c6aaff03a27a1
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.4"
+    version: "11.1.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "6.1.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   oauth2_client: ^4.2.0
   provider: ^6.1.5
   scroll_to_index: ^3.0.1
-  share_plus: ^10.1.4
+  share_plus: ^11.1.0
   shared_preferences: ^2.0.12
   showcaseview: ^4.0.1
   simple_chips_input: ^1.2.2


### PR DESCRIPTION
Fixes #426 

Describe the changes you have made in this PR -

- Updated `share_plus` dependency from `^10.1.4` to `^11.1.0`
- Replaced deprecated `Share.share()` with `SharePlus.instance.share()`
- Maintained existing sharing functionality with proper ShareParams usage

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Migrated project sharing to the newer sharing API for improved reliability and UI positioning; user sharing behavior remains the same.

- **Chores**
  - Upgraded sharing library dependency.
  - Updated Android build tooling and Gradle wrapper to newer versions for improved build compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->