### PR TITLE
fix(simulator): syncing webview and native

### DIFF
--- a/lib/ui/views/simulator/simulator_view.dart
+++ b/lib/ui/views/simulator/simulator_view.dart
@@ -87,7 +87,6 @@ class _SimulatorViewState extends State<SimulatorView> {
                       final action = await model.handleNavigation(
                         urlStr,
                         webViewController,
-                        context,
                       );
 
                       if (action == 'cancel') {

--- a/lib/ui/views/simulator/simulator_view.dart
+++ b/lib/ui/views/simulator/simulator_view.dart
@@ -81,6 +81,13 @@ class _SimulatorViewState extends State<SimulatorView> {
                       }
 
                       final urlStr = uri.toString();
+
+                      if (urlStr.contains('sign_out')) {
+                        model.clearCookies();
+                        Navigator.of(context).pop();
+                        return NavigationActionPolicy.CANCEL;
+                      }
+
                       final host = uri.host.toLowerCase();
                       final path = uri.path.toLowerCase();
                       final isLearn = host == 'learn.circuitverse.org';

--- a/lib/ui/views/simulator/simulator_view.dart
+++ b/lib/ui/views/simulator/simulator_view.dart
@@ -74,26 +74,30 @@ class _SimulatorViewState extends State<SimulatorView> {
                       useShouldOverrideUrlLoading: true,
                       useOnDownloadStart: true,
                     ),
-                    shouldOverrideUrlLoading: (controller, action) async {
-                      final uri = action.request.url;
+                    shouldOverrideUrlLoading: (
+                      controller,
+                      navigationAction,
+                    ) async {
+                      final uri = navigationAction.request.url;
                       if (uri == null) {
                         return NavigationActionPolicy.ALLOW;
                       }
 
                       final urlStr = uri.toString();
+                      final action = await model.handleNavigation(
+                        urlStr,
+                        webViewController,
+                        context,
+                      );
 
-                      if (urlStr.contains('sign_out')) {
-                        model.clearCookies();
-                        Navigator.of(context).pop();
+                      if (action == 'cancel') {
                         return NavigationActionPolicy.CANCEL;
                       }
 
-                      final host = uri.host.toLowerCase();
                       final path = uri.path.toLowerCase();
-                      final isLearn = host == 'learn.circuitverse.org';
                       final isPdf = path.endsWith('.pdf');
 
-                      if (isLearn || isPdf) {
+                      if (isPdf) {
                         final ok = await launchUrl(
                           Uri.parse(urlStr),
                           mode: LaunchMode.externalApplication,

--- a/lib/viewmodels/simulator/simulator_viewmodel.dart
+++ b/lib/viewmodels/simulator/simulator_viewmodel.dart
@@ -9,6 +9,7 @@ import 'package:mobile_app/locator.dart';
 import 'package:mobile_app/models/projects.dart';
 import 'package:mobile_app/services/local_storage_service.dart';
 import 'package:mobile_app/ui/views/authentication/login_view.dart';
+import 'package:mobile_app/ui/views/cv_landing_view.dart';
 import 'package:mobile_app/ui/views/ib/ib_landing_view.dart';
 import 'package:mobile_app/utils/snackbar_utils.dart';
 import 'package:mobile_app/viewmodels/base_viewmodel.dart';
@@ -287,41 +288,37 @@ class SimulatorViewModel extends BaseModel {
     }
   }
 
-  void clearCookies() async {
+  Future<void> clearCookies() async {
     await cookieManager.deleteAllCookies();
   }
 
-  bool findMatchInString(String url) {
+  Future<String?> handleNavigation(
+    String url,
+    InAppWebViewController? controller,
+    BuildContext context,
+  ) async {
     if (url.contains('learn.circuitverse.org')) {
       Get.offNamed(IbLandingView.id);
+      return 'cancel';
     } else if (url.contains('sign_in')) {
-      Get.offAndToNamed(LoginView.id);
+      if (_service.isLoggedIn && controller != null) {
+        await controller.loadUrl(
+          urlRequest: URLRequest(
+            url: WebUri.uri(Uri.parse(this.url)),
+            headers: {'Authorization': 'Token $token'},
+          ),
+        );
+        return 'cancel';
+      } else {
+        Get.offAndToNamed(LoginView.id);
+        return 'cancel';
+      }
     } else if (url.contains('sign_out')) {
-      clearCookies();
-      return true;
+      await clearCookies();
+      Navigator.of(context).pop();
+      return 'cancel';
     }
-
-    final components = url.split('/');
-    final length = components.length;
-
-    // Check for project edit URLs
-    if (components[length - 1] == 'edit' &&
-        components[length - 3] == 'projects') {
-      return true;
-    }
-
-    // Check for project save/update URLs
-    if (url.contains('projects') &&
-        (url.contains('saved') || url.contains('updated'))) {
-      return true;
-    }
-
-    // Check for groups or users URLs
-    if (url.contains('groups') || url.contains('users')) {
-      return true;
-    }
-
-    return false;
+    return null;
   }
 
   void onModelReady([Project? project]) {

--- a/lib/viewmodels/simulator/simulator_viewmodel.dart
+++ b/lib/viewmodels/simulator/simulator_viewmodel.dart
@@ -295,7 +295,6 @@ class SimulatorViewModel extends BaseModel {
   Future<String?> handleNavigation(
     String url,
     InAppWebViewController? controller,
-    BuildContext context,
   ) async {
     if (url.contains('learn.circuitverse.org')) {
       Get.offNamed(IbLandingView.id);
@@ -315,7 +314,7 @@ class SimulatorViewModel extends BaseModel {
       }
     } else if (url.contains('sign_out')) {
       await clearCookies();
-      Navigator.of(context).pop();
+      Get.offAndToNamed(CVLandingView.id);
       return 'cancel';
     }
     return null;


### PR DESCRIPTION
Fixes #447

**Changes:**
- Added detection for `sign_out` URL in the `shouldOverrideUrlLoading` callback
- Sign in redirects to app's native login flow  
- Used existing viewmodel logic to handle navigation events
- WebView intercepts and cancels sign_out/sign_in URLs before they load

Screenshots of the changes (If any) -

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.
