### PR TITLE
feat: improve theme toggle component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# FVM Version Cache
+.fvm/
+.fvmrc 

--- a/lib/ui/components/cv_drawer.dart
+++ b/lib/ui/components/cv_drawer.dart
@@ -6,6 +6,7 @@ import 'package:fluttericon/font_awesome_icons.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/cv_theme.dart';
 import 'package:mobile_app/ui/components/cv_drawer_tile.dart';
+import 'package:mobile_app/ui/components/cv_theme_toggle_button.dart';
 import 'package:mobile_app/ui/views/authentication/login_view.dart';
 import 'package:mobile_app/ui/views/ib/ib_landing_view.dart';
 import 'package:mobile_app/ui/views/simulator/simulator_view.dart';
@@ -239,16 +240,24 @@ class CVDrawer extends StatelessWidget {
                 ),
             ],
           ),
+          // Positioned(
+          //   right: 5,
+          //   top: 35,
+          //   child: IconButton(
+          //     icon:
+          //         Theme.of(context).brightness == Brightness.dark
+          //             ? const Icon(Icons.brightness_low)
+          //             : const Icon(Icons.brightness_high),
+          //     iconSize: 28.0,
+          //     onPressed: () => ThemeProvider.controllerOf(context).nextTheme(),
+          //   ),
+          // ),
           Positioned(
             right: 5,
             top: 35,
-            child: IconButton(
-              icon:
-                  Theme.of(context).brightness == Brightness.dark
-                      ? const Icon(Icons.brightness_low)
-                      : const Icon(Icons.brightness_high),
-              iconSize: 28.0,
-              onPressed: () => ThemeProvider.controllerOf(context).nextTheme(),
+            child: ThemeToggleButton(
+              isDark: Theme.of(context).brightness == Brightness.dark,
+              onToggle: () => ThemeProvider.controllerOf(context).nextTheme(),
             ),
           ),
         ],

--- a/lib/ui/components/cv_theme_toggle_button.dart
+++ b/lib/ui/components/cv_theme_toggle_button.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+class ThemeToggleButton extends StatelessWidget {
+  final bool isDark;
+  final VoidCallback onToggle;
+
+  const ThemeToggleButton({
+    super.key,
+    required this.isDark,
+    required this.onToggle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final double scale = MediaQuery.of(context).textScaleFactor;
+
+    return GestureDetector(
+      onTap: onToggle,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 350),
+        curve: Curves.easeInOut,
+        width: 64 * scale.clamp(1.0, 1.2),
+        height: 34 * scale.clamp(1.0, 1.2),
+        padding: const EdgeInsets.all(3),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(40),
+          color: isDark ? const Color(0xFF1E1E1E) : Colors.grey.shade200,
+
+          // 🔥 WHITE BORDER (BOTH THEMES)
+          border: Border.all(color: Colors.white, width: 1.5),
+
+          // 🌫️ Soft shadow for depth
+          boxShadow: [
+            BoxShadow(
+              color:
+                  isDark
+                      ? Colors.black.withOpacity(0.6)
+                      : Colors.grey.withOpacity(0.5),
+              blurRadius: 6,
+              offset: const Offset(0, 3),
+            ),
+          ],
+        ),
+        child: AnimatedAlign(
+          duration: const Duration(milliseconds: 350),
+          curve: Curves.easeInOut,
+          alignment: isDark ? Alignment.centerRight : Alignment.centerLeft,
+          child: Container(
+            width: 26,
+            height: 26,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: Colors.white,
+
+              // ✨ Knob glow
+              boxShadow: [
+                BoxShadow(
+                  color:
+                      isDark
+                          ? Colors.blueAccent.withOpacity(0.4)
+                          : Colors.orange.withOpacity(0.4),
+                  blurRadius: 6,
+                ),
+              ],
+            ),
+            child: Icon(
+              isDark ? Icons.nightlight_round : Icons.wb_sunny,
+              size: 16,
+              color: isDark ? Colors.black : Colors.orange,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 🌓 Improve Theme Toggle UI with Day/Night Switch

### Problem
The current theme toggle is implemented as a single icon button (sun/moon).  
While the theme switching logic works correctly, the UI does not clearly indicate the current theme state, which can be confusing for users.

### Solution
This PR replaces the existing icon button with an intuitive **Day/Night toggle switch** that:
- Clearly reflects the current theme state
- Uses visual cues (sun for light mode, moon for dark mode)
- Provides a more accessible and user-friendly interaction

### What changed
- Replaced the icon-only theme toggle with a toggle-style UI component
- Preserved existing theme logic using `ThemeProvider.controllerOf(context).nextTheme()`
- No changes to theme management or business logic

### UX Improvements
- Users can instantly identify the active theme
- One-tap, intuitive toggle interaction
- Improved clarity for new and accessibility-focused users

### Screenshots / Video
before changes 
<img width="540" height="1196" alt="image" src="https://github.com/user-attachments/assets/1b54c48f-9e4e-4668-bc78-62ac48b7fe3a" />

after changes

<img width="540" height="1196" alt="image" src="https://github.com/user-attachments/assets/f8c9a500-820b-4092-af4e-6117d2937e03" />


### Related Issue
Fixes #462

### Checklist
- [x] Code formatted using `dart format`
- [x] Analyzer passes (`flutter analyze`)
- [x] No breaking changes
- [x] UI-only change (logic untouched)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the theme toggle button with smooth animations and adaptive visual styling. The button now features animated transitions, theme-aware colors, and intuitive icons that reflect the current theme state (light or dark).

* **Chores**
  * Updated .gitignore configuration to properly exclude FVM (Flutter Version Manager) files and directories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->