### PR TITLE
chore(deps): align SDK constraints and README with dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Follow these instructions to build and run the project
 
 ### Prerequisites
 
-- Flutter `3.32.2` (stable)
-- Dart `3.8.1`
+- Flutter `3.35.0` (stable)
+- Dart `3.9.0`
 
 > Tip: To ensure you’re always using the correct Flutter version, consider using [FVM (Flutter Version Manager)](https://fvm.app/) to manage versions.
 
@@ -46,7 +46,7 @@ Make sure you have a connected Android/iOS device/simulator and run the followin
 
 ### Android OAuth Config
 
-This project uses Flutter 3.32.2 and hence the support for compile-time variables. To use compile-time variables pass them in `--dart-defines` as `flutter run --dart-define=VAR_NAME=VAR_VALUE`. Supported `dart-defines` include :
+ This project uses Flutter 3.35.0 and hence the support for compile-time variables. To use compile-time variables pass them in `--dart-defines` as `flutter run --dart-define=VAR_NAME=VAR_VALUE`. Supported `dart-defines` include :
 
 #### GitHub Configuration
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -959,7 +959,7 @@ packages:
     source: hosted
     version: "1.0.6"
   mockito:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: mockito
       sha256: "6841eed20a7befac0ce07df8116c8b8233ed1f4486a7647c7fc5a02ae6163917"
@@ -1740,5 +1740,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.27.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: none
 version: 1.3.0+6
 
 environment:
-  sdk: ">=3.7.2 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 dependencies:
   animations: ^2.0.2


### PR DESCRIPTION
Fixes #478 

Describe the changes you have made in this PR -
This PR resolves `flutter pub get`  failed for new contributors following the readme instructions.

1. SDK Constraint Update: Updated pubspec.yaml the environment to sdk: ">=3.9.0 <4.0.0".

> This is required because shared_preferences ^2.5.4 (updated in #466) explicitly requires Dart ≥ 3.9.0.

2. Documentation Update: Updated the README.md prerequisites to recommend Flutter ≥ 3.35.0 and Dart ≥ 3.9.0 to match the new project requirements.

3. Onboarding Fix: Ensures new developers can successfully resolve dependencies and build the app without "forbidden version" errors during their initial local environment setup.

Screenshots of the changes (If any) -null

Note: Please check Allow edits from maintainers. If you would like us to assist with the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated prerequisites to reflect newer Flutter (3.35.0) and Dart (3.9.0) versions and clarified Android OAuth setup wording; minor formatting tweaks.

* **Chores**
  * Raised the minimum Flutter/Dart SDK constraint in project configuration to require the newer SDK versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->