### PR TITLE
Update build_runner command to modern Dart CLI syntax in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A detailed guide for multiple platforms setup can be found [in the Flutter insta
 - `flutter pub get` to get all the dependencies.
 - Generate files using Builder Runner (**required**) 
 ```
-flutter pub run build_runner build --delete-conflicting-outputs
+dart run build_runner build --delete-conflicting-outputs
 ```
 - Switch to mobile-app's git hooks (**optional but recommended**)
 ```


### PR DESCRIPTION
Fixes #

Describe the changes you have made in this PR -
This PR updates the build_runner command in the `README.md` file. The previous command `flutter pub run` is now deprecated in favor of the unified `dart run` syntax introduced in recent Dart/Flutter SDK versions.

Updated `flutter pub run build_runner build --delete-conflicting-outputs` to `dart run build_runner build --delete-conflicting-outputs` in `README`

Screenshots of the changes (If any) -Nil

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project setup instructions to use a Dart command for generating builder outputs instead of the previous Flutter-specific tooling. All build functionality and output behavior remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->