### PR TITLE
Upgrade AGP to 8.9.1, Kotlin to 2.1.0, and Android SDK to 36

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -51,7 +51,7 @@ if (releaseKeystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdk 35
+    compileSdk 36
     namespace 'org.circuitverse.mobile_app'
 
     compileOptions {
@@ -73,7 +73,7 @@ android {
 
     defaultConfig {
         applicationId "org.circuitverse.mobile_app"
-        minSdkVersion 23
+        minSdkVersion 24
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -74,7 +74,7 @@ android {
     defaultConfig {
         applicationId "org.circuitverse.mobile_app"
         minSdkVersion 24
-        targetSdkVersion 33
+        targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.7.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.25" apply false
+    id "com.android.application" version "8.9.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"


### PR DESCRIPTION
Fixes #484 

**Describe the changes you have made in this PR:**

This PR fixes Android build failures caused by outdated build configurations and deprecated settings. The changes ensure compatibility with the latest Flutter plugins and Android dependencies.

**Changes made:**

1. **settings.gradle** - Upgraded Android Gradle Plugin from 8.7.0 to 8.9.1 (required by androidx.browser:1.9.0)
2. **settings.gradle** - Upgraded Kotlin version from 1.9.25 to 2.1.0 (addressing Flutter deprecation warning)
3. **build.gradle** - Updated `compileSdk` from 35 to 36 (required by multiple plugins including flutter_secure_storage, google_sign_in_android, etc.)
4. **build.gradle** - Updated `minSdkVersion` from 21 to 24 (required by flutter_secure_storage)

**Why these changes are necessary:**
- Multiple Flutter plugins (flutter_secure_storage, google_sign_in_android, webview_flutter_android, etc.) require Android SDK 36
- androidx.browser:1.9.0 dependency mandates AGP 8.9.1+
- Flutter officially warns that Kotlin 1.9.25 support will be dropped soon
- flutter_secure_storage requires minimum API level 24

**Screenshots of the changes (If any):**
N/A - Configuration changes only, no UI changes

**Testing:**
- [x] Build completes successfully with `flutter build apk`
- [x] App runs without errors on Android emulator
- [x] No deprecation warnings in build output except for (`synthetic-package`) which is out of scope of the PR



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Android SDK targets: compileSdk -> 36, targetSdk -> 35, minSdk -> 24.
  * Upgraded Gradle wrapper to 8.11.1.
  * Bumped Android Gradle plugin and Kotlin plugin to newer versions.
  * Minor formatting cleanup (end-of-file newline).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->