### PR TITLE
Deeplinks manager

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,7 +52,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          flutter-version: 3.32
+          flutter-version: 3.35.2
 
           
       - name: Install semantic-release and plugins
@@ -155,7 +155,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          flutter-version: 3.32
+          flutter-version: 3.35.2
           
       - name: Set up Java
         uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: 3.32
+          flutter-version: 3.35.2
           
       - name: Cache pub dependencies
         uses: actions/cache@v5
@@ -126,7 +126,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: 3.32
+          flutter-version: 3.35.2
 
           
       - name: Cache Gradle (Android)
@@ -305,7 +305,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: 3.32
+          flutter-version: 3.35.2
 
           
       - name: Cache Gradle

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -19,7 +19,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: 3.32
+          flutter-version: 3.35.2
 
       - name: Get Dependencies
         run: |

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -68,6 +68,17 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!-- Deep Linking -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:host="circuitverse.org" />
+                <data android:host="www.circuitverse.org" />
+            </intent-filter>
         </activity>
         
         <!-- Don't delete the meta-data below.

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -15,6 +15,7 @@ import 'package:mobile_app/services/API/contributors_api.dart';
 import 'package:mobile_app/services/ib_engine_service.dart';
 import 'package:mobile_app/services/local_storage_service.dart';
 import 'package:mobile_app/services/notifications_service.dart';
+import 'package:mobile_app/services/deep_link_manager.dart';
 import 'package:mobile_app/viewmodels/authentication/auth_options_viewmodel.dart';
 import 'package:mobile_app/viewmodels/authentication/forgot_password_viewmodel.dart';
 import 'package:mobile_app/viewmodels/authentication/login_viewmodel.dart';
@@ -59,6 +60,9 @@ Future<void> setupLocator() async {
   locator.registerLazySingleton<NotificationsService>(
     () => NotificationsServiceImpl(),
   );
+  
+  // Deep Link Manager
+  locator.registerLazySingleton<DeepLinkManager>(() => DeepLinkManager());
 
   // API Services
   locator.registerLazySingleton<ContributorsApi>(() => HttpContributorsApi());

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -61,7 +61,6 @@ Future<void> setupLocator() async {
     () => NotificationsServiceImpl(),
   );
   
-  // Deep Link Manager
   locator.registerLazySingleton<DeepLinkManager>(() => DeepLinkManager());
 
   // API Services

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -60,7 +60,7 @@ Future<void> setupLocator() async {
   locator.registerLazySingleton<NotificationsService>(
     () => NotificationsServiceImpl(),
   );
-  
+
   locator.registerLazySingleton<DeepLinkManager>(() => DeepLinkManager());
 
   // API Services

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,7 +22,6 @@ Future<void> main() async {
   // Init Hive
   await locator<DatabaseService>().init();
   
-  // Init Deep Links
   locator<DeepLinkManager>().init();
   
   Get.put(LanguageController());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,9 +21,9 @@ Future<void> main() async {
 
   // Init Hive
   await locator<DatabaseService>().init();
-  
+
   locator<DeepLinkManager>().init();
-  
+
   Get.put(LanguageController());
 
   runApp(const CircuitVerseMobile());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:get/get.dart';
 import 'package:mobile_app/cv_theme.dart';
 import 'package:mobile_app/locator.dart';
 import 'package:mobile_app/services/database_service.dart';
+import 'package:mobile_app/services/deep_link_manager.dart';
 import 'package:mobile_app/utils/router.dart';
 import 'package:theme_provider/theme_provider.dart';
 import 'package:mobile_app/ui/views/startup_view.dart';
@@ -20,6 +21,10 @@ Future<void> main() async {
 
   // Init Hive
   await locator<DatabaseService>().init();
+  
+  // Init Deep Links
+  locator<DeepLinkManager>().init();
+  
   Get.put(LanguageController());
 
   runApp(const CircuitVerseMobile());

--- a/lib/models/projects.dart
+++ b/lib/models/projects.dart
@@ -33,6 +33,26 @@ class Project {
             )
             : null,
   );
+
+  factory Project.idOnly(String id) => Project(
+    id: id,
+    type: 'project',
+    attributes: ProjectAttributes(
+      name: '',
+      projectAccessType: '',
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+      imagePreview: ImagePreview(url: ''),
+      view: 0,
+      tags: [],
+      isStarred: false,
+      authorName: '',
+      starsCount: 0,
+    ),
+    relationships: ProjectRelationships(
+      author: Author(data: AuthorData(id: '', type: 'user')),
+    ),
+  );
   Project({
     required this.id,
     required this.type,

--- a/lib/services/deep_link_manager.dart
+++ b/lib/services/deep_link_manager.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+import 'package:app_links/app_links.dart';
+import 'package:get/get.dart';
+import 'package:mobile_app/locator.dart';
+import 'package:mobile_app/models/projects.dart';
+import 'package:mobile_app/services/API/projects_api.dart';
+import 'package:mobile_app/services/dialog_service.dart';
+import 'package:mobile_app/ui/views/projects/project_details_view.dart';
+import 'package:mobile_app/ui/views/simulator/simulator_view.dart';
+import 'package:mobile_app/utils/snackbar_utils.dart';
+
+class DeepLinkManager {
+  final _appLinks = AppLinks();
+  StreamSubscription<Uri>? _linkSubscription;
+
+  void init() {
+    // Check initial link
+    _checkInitialLink();
+
+    // Listen to link changes
+    _linkSubscription = _appLinks.uriLinkStream.listen((uri) {
+      _handleLink(uri);
+    });
+  }
+
+  Future<void> _checkInitialLink() async {
+    try {
+      final uri = await _appLinks.getInitialLink();
+      if (uri != null) {
+        _handleLink(uri);
+      }
+    } catch (e) {
+      // Ignore errors handling initial link
+    }
+  }
+
+  void dispose() {
+    _linkSubscription?.cancel();
+  }
+
+  // Handle incoming links
+  Future<void> _handleLink(Uri uri) async {
+    // Basic validation for host
+    if (uri.host != 'circuitverse.org' && uri.host != 'www.circuitverse.org') {
+      return;
+    }
+
+    final pathSegments = uri.pathSegments;
+    if (pathSegments.isEmpty) return;
+
+    // Pattern: /simulator/edit/:projectId OR /simulator/embed/:projectId
+    if (pathSegments.length >= 3 && pathSegments[0] == 'simulator') {
+      final mode = pathSegments[1]; // 'edit' or 'embed'
+      final projectId = pathSegments[2];
+
+      if (mode == 'edit' || mode == 'embed') {
+        final dummyProject = Project.idOnly(projectId);
+        final isEmbed = mode == 'embed';
+
+        // Navigate to SimulatorView with the project and isEmbed flag
+        // We pass the flag via arguments map or just handling it in View
+        // Since we are using Get.toNamed, let's pass it in arguments if possible, 
+        // but SimulatorView expects `Project?` as arguments.
+        // We will modify SimulatorView to check for this extra data or handle it differently.
+        // For now, let's assume we update SimulatorView to handle a Map or a custom helper.
+        // Or simpler: We pass the Project, and we can't easily pass the bool unless we change arguments type.
+        // Let's pass a Map that contains 'project' and 'isEmbed'.
+        
+        Get.toNamed(SimulatorView.id, arguments: {
+          'project': dummyProject,
+          'isEmbed': isEmbed,
+        });
+        return;
+      }
+    }
+
+    // Pattern: /users/:userId/projects/:projectId
+    if (pathSegments.length >= 4 &&
+        pathSegments[0] == 'users' &&
+        pathSegments[2] == 'projects') {
+      final projectId = pathSegments[3];
+      _fetchAndNavigateToProject(projectId);
+      return;
+    }
+  }
+
+  Future<void> _fetchAndNavigateToProject(String projectId) async {
+    // We need to wait a bit if the app is just starting up to ensure GetX context is ready
+    // or use a slight delay.
+    // However, since this might be called after init, it should be fine.
+    
+    final dialogService = locator<DialogService>();
+    dialogService.showCustomProgressDialog(title: 'Loading Project...');
+
+    try {
+      final project = await locator<ProjectsApi>().getProjectDetails(projectId);
+      dialogService.popDialog();
+
+      if (project != null) {
+        Get.toNamed(ProjectDetailsView.id, arguments: project);
+      }
+    } catch (e) {
+      dialogService.popDialog();
+      SnackBarUtils.showDark('Error', 'Could not load project details.');
+    }
+  }
+}

--- a/lib/services/deep_link_manager.dart
+++ b/lib/services/deep_link_manager.dart
@@ -29,8 +29,7 @@ class DeepLinkManager {
       if (uri != null) {
         _handleLink(uri);
       }
-    } catch (e) {
-    }
+    } catch (e) {}
   }
 
   void dispose() {
@@ -53,10 +52,10 @@ class DeepLinkManager {
       if (mode == 'edit' || mode == 'embed') {
         final dummyProject = Project.idOnly(projectId);
         final isEmbed = mode == 'embed';
-        Get.toNamed(SimulatorView.id, arguments: {
-          'project': dummyProject,
-          'isEmbed': isEmbed,
-        });
+        Get.toNamed(
+          SimulatorView.id,
+          arguments: {'project': dummyProject, 'isEmbed': isEmbed},
+        );
         return;
       }
     }
@@ -72,7 +71,6 @@ class DeepLinkManager {
   }
 
   Future<void> _fetchAndNavigateToProject(String projectId) async {
-
     try {
       final project = await locator<ProjectsApi>().getProjectDetails(projectId);
 
@@ -112,11 +110,7 @@ class DeepLinkManager {
           segments[0] == 'users' &&
           segments[2] == 'projects') {
         return CVRouter.buildRoute(
-          const Scaffold(
-            body: Center(
-              child: CircularProgressIndicator(),
-            ),
-          ),
+          const Scaffold(body: Center(child: CircularProgressIndicator())),
           settings: settings,
         );
       }

--- a/lib/services/deep_link_manager.dart
+++ b/lib/services/deep_link_manager.dart
@@ -45,7 +45,7 @@ class DeepLinkManager {
     final pathSegments = uri.pathSegments;
     if (pathSegments.isEmpty) return;
 
-    // Pattern: /simulator/edit/:projectId OR /simulator/embed/:projectId
+    // /simulator/edit/:projectId OR /simulator/embed/:projectId
     if (pathSegments.length >= 3 && pathSegments[0] == 'simulator') {
       final mode = pathSegments[1]; // 'edit' or 'embed'
       final projectId = pathSegments[2];
@@ -61,7 +61,7 @@ class DeepLinkManager {
       }
     }
 
-    // Pattern: /users/:userId/projects/:projectId
+    // /users/:userId/projects/:projectId
     if (pathSegments.length >= 4 &&
         pathSegments[0] == 'users' &&
         pathSegments[2] == 'projects') {
@@ -73,19 +73,13 @@ class DeepLinkManager {
 
   Future<void> _fetchAndNavigateToProject(String projectId) async {
 
-    
-    final dialogService = locator<DialogService>();
-    dialogService.showCustomProgressDialog(title: 'Loading Project...');
-
     try {
       final project = await locator<ProjectsApi>().getProjectDetails(projectId);
-      dialogService.popDialog();
 
       if (project != null) {
-        Get.toNamed(ProjectDetailsView.id, arguments: project);
+        Get.offNamed(ProjectDetailsView.id, arguments: project);
       }
     } catch (e) {
-      dialogService.popDialog();
       SnackBarUtils.showDark('Error', 'Could not load project details.');
     }
   }
@@ -93,9 +87,10 @@ class DeepLinkManager {
   static Route<dynamic>? generateRoute(RouteSettings settings) {
     final name = settings.name;
     if (name != null) {
+      final uri = Uri.parse(name);
+      final segments = uri.pathSegments;
       if (name.startsWith('/simulator/edit/') ||
           name.startsWith('/simulator/embed/')) {
-        final segments = Uri.parse(name).pathSegments;
         if (segments.length >= 3) {
           final mode = segments[1];
           final projectId = segments[2];
@@ -110,6 +105,20 @@ class DeepLinkManager {
             ),
           );
         }
+      }
+
+      // Pattern: /users/:userId/projects/:projectId
+      if (segments.length >= 4 &&
+          segments[0] == 'users' &&
+          segments[2] == 'projects') {
+        return CVRouter.buildRoute(
+          const Scaffold(
+            body: Center(
+              child: CircularProgressIndicator(),
+            ),
+          ),
+          settings: settings,
+        );
       }
     }
     return null;

--- a/lib/ui/views/simulator/simulator_view.dart
+++ b/lib/ui/views/simulator/simulator_view.dart
@@ -21,13 +21,22 @@ class _SimulatorViewState extends State<SimulatorView> {
 
   @override
   Widget build(BuildContext context) {
-    // Get the project argument if passed
-    final Project? project = Get.arguments as Project?;
+    // Get arguments which can be Project or Map (from deep link)
+    final args = Get.arguments;
+    Project? project;
+    bool isEmbed = false;
+
+    if (args is Project) {
+      project = args;
+    } else if (args is Map) {
+      project = args['project'] as Project?;
+      isEmbed = args['isEmbed'] as bool? ?? false;
+    }
 
     return Scaffold(
       body: SafeArea(
         child: BaseView<SimulatorViewModel>(
-          onModelReady: (model) => model.onModelReady(project),
+          onModelReady: (model) => model.onModelReady(project, isEmbed: isEmbed),
           onModelDestroy: (model) => model.onModelDestroy(),
           builder: (context, model, child) {
             return PopScope(

--- a/lib/ui/views/simulator/simulator_view.dart
+++ b/lib/ui/views/simulator/simulator_view.dart
@@ -21,7 +21,6 @@ class _SimulatorViewState extends State<SimulatorView> {
 
   @override
   Widget build(BuildContext context) {
-    // Get arguments which can be Project or Map (from deep link)
     final args = Get.arguments;
     Project? project;
     bool isEmbed = false;

--- a/lib/ui/views/simulator/simulator_view.dart
+++ b/lib/ui/views/simulator/simulator_view.dart
@@ -35,7 +35,8 @@ class _SimulatorViewState extends State<SimulatorView> {
     return Scaffold(
       body: SafeArea(
         child: BaseView<SimulatorViewModel>(
-          onModelReady: (model) => model.onModelReady(project, isEmbed: isEmbed),
+          onModelReady:
+              (model) => model.onModelReady(project, isEmbed: isEmbed),
           onModelDestroy: (model) => model.onModelDestroy(),
           builder: (context, model, child) {
             return PopScope(

--- a/lib/utils/router.dart
+++ b/lib/utils/router.dart
@@ -15,6 +15,7 @@ import 'package:mobile_app/ui/views/groups/group_details_view.dart';
 import 'package:mobile_app/ui/views/groups/my_groups_view.dart';
 import 'package:mobile_app/ui/views/groups/new_group_view.dart';
 import 'package:mobile_app/ui/views/groups/update_assignment_view.dart';
+import 'package:mobile_app/services/deep_link_manager.dart';
 import 'package:mobile_app/ui/views/cv_landing_view.dart';
 import 'package:mobile_app/ui/views/ib/ib_landing_view.dart';
 import 'package:mobile_app/ui/views/profile/edit_profile_view.dart';
@@ -28,68 +29,73 @@ import 'package:mobile_app/ui/views/teachers/teachers_view.dart';
 
 class CVRouter {
   static Route<dynamic> generateRoute(RouteSettings settings) {
+    final deepLinkRoute = DeepLinkManager.generateRoute(settings);
+    if (deepLinkRoute != null) {
+      return deepLinkRoute;
+    }
+
     switch (settings.name) {
       case SignupView.id:
-        return _buildRoute(const SignupView());
+        return buildRoute(const SignupView());
       case LoginView.id:
-        return _buildRoute(const LoginView());
+        return buildRoute(const LoginView());
       case ForgotPasswordView.id:
-        return _buildRoute(const ForgotPasswordView());
+        return buildRoute(const ForgotPasswordView());
       case CVLandingView.id:
-        return _buildRoute(const CVLandingView());
+        return buildRoute(const CVLandingView());
       case SimulatorView.id:
-        final project = settings.arguments as Project?;
-        return _buildRoute(
+        final args = settings.arguments;
+        return buildRoute(
           const SimulatorView(),
-          settings: RouteSettings(name: SimulatorView.id, arguments: project),
+          settings: RouteSettings(name: SimulatorView.id, arguments: args),
         );
       case TeachersView.id:
-        return _buildRoute(const TeachersView());
+        return buildRoute(const TeachersView());
       case ContributorsView.id:
-        return _buildRoute(const ContributorsView());
+        return buildRoute(const ContributorsView());
       case AboutTosView.id:
-        return _buildRoute(const AboutTosView());
+        return buildRoute(const AboutTosView());
       case AboutPrivacyPolicyView.id:
-        return _buildRoute(const AboutPrivacyPolicyView());
+        return buildRoute(const AboutPrivacyPolicyView());
       case FeaturedProjectsView.id:
-        return _buildRoute(const FeaturedProjectsView());
+        return buildRoute(const FeaturedProjectsView());
       case ProfileView.id:
         var _userId = settings.arguments as String;
-        return _buildRoute(ProfileView(userId: _userId));
+        return buildRoute(ProfileView(userId: _userId));
       case EditProfileView.id:
-        return _buildRoute(const EditProfileView());
+        return buildRoute(const EditProfileView());
       case ProjectDetailsView.id:
         var _project = settings.arguments as Project;
-        return _buildRoute(ProjectDetailsView(project: _project));
+        return buildRoute(ProjectDetailsView(project: _project));
       case EditProjectView.id:
         var _project = settings.arguments as Project;
-        return _buildRoute(EditProjectView(project: _project));
+        return buildRoute(EditProjectView(project: _project));
       case MyGroupsView.id:
-        return _buildRoute(const MyGroupsView());
+        return buildRoute(const MyGroupsView());
       case GroupDetailsView.id:
         var group = settings.arguments as Group;
-        return _buildRoute(GroupDetailsView(group: group));
+        return buildRoute(GroupDetailsView(group: group));
       case NewGroupView.id:
-        return _buildRoute(const NewGroupView());
+        return buildRoute(const NewGroupView());
       case EditGroupView.id:
         var group = settings.arguments as Group;
-        return _buildRoute(EditGroupView(group: group));
+        return buildRoute(EditGroupView(group: group));
       case AssignmentDetailsView.id:
         var _assignment = settings.arguments as Assignment;
-        return _buildRoute(AssignmentDetailsView(assignment: _assignment));
+        return buildRoute(AssignmentDetailsView(assignment: _assignment));
       case AddAssignmentView.id:
         var _groupId = settings.arguments as String;
-        return _buildRoute(AddAssignmentView(groupId: _groupId));
+        return buildRoute(AddAssignmentView(groupId: _groupId));
       case UpdateAssignmentView.id:
         var _assignment = settings.arguments as Assignment;
-        return _buildRoute(UpdateAssignmentView(assignment: _assignment));
+        return buildRoute(UpdateAssignmentView(assignment: _assignment));
       case IbLandingView.id:
-        return _buildRoute(const IbLandingView());
+        return buildRoute(const IbLandingView());
       case ProjectPreviewFullScreen.id:
         var _project = settings.arguments as Project;
-        return _buildRoute(ProjectPreviewFullScreen(project: _project));
+        return buildRoute(ProjectPreviewFullScreen(project: _project));
       default:
-        return _buildRoute(
+        return buildRoute(
           Scaffold(
             body: Center(child: Text('No route defined for ${settings.name}')),
           ),
@@ -98,7 +104,7 @@ class CVRouter {
   }
 
   /// Premium fade + scale transition for optimal user experience
-  static PageRouteBuilder _buildRoute(Widget page, {RouteSettings? settings}) {
+  static PageRouteBuilder buildRoute(Widget page, {RouteSettings? settings}) {
     return PageRouteBuilder(
       settings: settings,
       transitionDuration: const Duration(milliseconds: 350),

--- a/lib/viewmodels/simulator/simulator_viewmodel.dart
+++ b/lib/viewmodels/simulator/simulator_viewmodel.dart
@@ -33,9 +33,13 @@ class SimulatorViewModel extends BaseModel {
 
   // Project to edit
   Project? _projectToEdit;
+  bool _isEmbed = false;
 
   String get url {
     if (_projectToEdit != null) {
+      if (_isEmbed) {
+        return '${EnvironmentConfig.CV_BASE_URL}/simulator/embed/${_projectToEdit!.id}';
+      }
       return '${EnvironmentConfig.CV_BASE_URL}/simulator/edit/${_projectToEdit!.id}';
     }
     return '${EnvironmentConfig.CV_BASE_URL}/simulator';
@@ -324,7 +328,8 @@ class SimulatorViewModel extends BaseModel {
     return false;
   }
 
-  void onModelReady([Project? project]) {
+  void onModelReady(Project? project, {bool isEmbed = false}) {
+    _isEmbed = isEmbed;
     if (project != null) {
       setProjectToEdit(project);
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,6 +25,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.11"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: "5f88447519add627fe1cbcab4fd1da3d4fed15b9baf29f28b22535c95ecee3e8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: transitive
+    description:
+      name: app_links_platform_interface
+      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   args:
     dependency: transitive
     description:
@@ -685,6 +717,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: e8ce9ca4b1df106e4d72dad201d345ea1a036cc12c360f1a7d5a758f78ffa42c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   hive:
     dependency: "direct main"
     description:
@@ -946,10 +986,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: "direct overridden"
     description:
@@ -959,7 +999,7 @@ packages:
     source: hosted
     version: "1.0.6"
   mockito:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: mockito
       sha256: "6841eed20a7befac0ce07df8116c8b8233ed1f4486a7647c7fc5a02ae6163917"
@@ -1471,10 +1511,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   theme_provider:
     dependency: "direct main"
     description:
@@ -1740,5 +1780,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.27.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   markdown: any
   webview_flutter: 4.13.1
   flutter_quill: ^11.4.2
+  app_links: ^6.4.1
 dev_dependencies:
   mockito: ^5.4.4
   build_runner: ^2.4.13


### PR DESCRIPTION
Fixes #482

Describe the changes you have made in this PR -

Added a Deep Link Manager using the app_links dependency.

- Now, when a user opens a supported (shareable) link and the app is already installed, it correctly opens inside the app instead of the browser.
- To make this work completely, we need to host our SHA key on the original website as required for app link verification. Related issue: https://github.com/CircuitVerse/CircuitVerse/issues/6720

Screenshots of the changes (If any) -
A demonstration video on how the links would work (in the video i have used adb for deeplinks but once assets is hosted, if we click on any link example: "https://circuitverse.org/simulator/embed/5010", it would open our app the same way as in video.

https://github.com/user-attachments/assets/06e82915-524b-4694-a752-6163fe6eccb9


Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds deep linking so users can open projects and simulator views directly from circuitverse.org URLs (including edit and embed modes).
  * Deep links support navigating to project details pages from shared links.

* **Chores**
  * Added runtime link handling dependency.
  * Updated CI/workflow Flutter versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->