### PR TITLE
Add deeplink manager

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,7 +52,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          flutter-version: 3.32
+          flutter-version: 3.35
 
           
       - name: Install semantic-release and plugins
@@ -155,7 +155,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          flutter-version: 3.32
+          flutter-version: 3.35
           
       - name: Set up Java
         uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: 3.32
+          flutter-version: 3.35
           
       - name: Cache pub dependencies
         uses: actions/cache@v5
@@ -126,7 +126,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: 3.32
+          flutter-version: 3.35
 
           
       - name: Cache Gradle (Android)
@@ -305,7 +305,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: 3.32
+          flutter-version: 3.35
 
           
       - name: Cache Gradle

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -19,7 +19,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: 3.32
+          flutter-version: 3.35
 
       - name: Get Dependencies
         run: |

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -74,10 +74,24 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="http" />
-                <data android:scheme="https" />
-                <data android:host="circuitverse.org" />
-                <data android:host="www.circuitverse.org" />
+                
+                <!-- Simulator Edit -->
+                <data android:scheme="http" android:host="circuitverse.org" android:pathPrefix="/simulator/edit/" />
+                <data android:scheme="https" android:host="circuitverse.org" android:pathPrefix="/simulator/edit/" />
+                <data android:scheme="http" android:host="www.circuitverse.org" android:pathPrefix="/simulator/edit/" />
+                <data android:scheme="https" android:host="www.circuitverse.org" android:pathPrefix="/simulator/edit/" />
+
+                <!-- Simulator Embed -->
+                <data android:scheme="http" android:host="circuitverse.org" android:pathPrefix="/simulator/embed/" />
+                <data android:scheme="https" android:host="circuitverse.org" android:pathPrefix="/simulator/embed/" />
+                <data android:scheme="http" android:host="www.circuitverse.org" android:pathPrefix="/simulator/embed/" />
+                <data android:scheme="https" android:host="www.circuitverse.org" android:pathPrefix="/simulator/embed/" />
+
+                <!-- User Project -->
+                <data android:scheme="http" android:host="circuitverse.org" android:pathPattern="/users/.*/projects/.*" />
+                <data android:scheme="https" android:host="circuitverse.org" android:pathPattern="/users/.*/projects/.*" />
+                <data android:scheme="http" android:host="www.circuitverse.org" android:pathPattern="/users/.*/projects/.*" />
+                <data android:scheme="https" android:host="www.circuitverse.org" android:pathPattern="/users/.*/projects/.*" />
             </intent-filter>
         </activity>
         

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -68,6 +68,17 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!-- Deep Linking -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:host="circuitverse.org" />
+                <data android:host="www.circuitverse.org" />
+            </intent-filter>
         </activity>
         
         <!-- Don't delete the meta-data below.

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -15,6 +15,7 @@ import 'package:mobile_app/services/API/contributors_api.dart';
 import 'package:mobile_app/services/ib_engine_service.dart';
 import 'package:mobile_app/services/local_storage_service.dart';
 import 'package:mobile_app/services/notifications_service.dart';
+import 'package:mobile_app/services/deep_link_manager.dart';
 import 'package:mobile_app/viewmodels/authentication/auth_options_viewmodel.dart';
 import 'package:mobile_app/viewmodels/authentication/forgot_password_viewmodel.dart';
 import 'package:mobile_app/viewmodels/authentication/login_viewmodel.dart';
@@ -59,6 +60,8 @@ Future<void> setupLocator() async {
   locator.registerLazySingleton<NotificationsService>(
     () => NotificationsServiceImpl(),
   );
+
+  locator.registerLazySingleton<DeepLinkManager>(() => DeepLinkManager());
 
   // API Services
   locator.registerLazySingleton<ContributorsApi>(() => HttpContributorsApi());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:get/get.dart';
 import 'package:mobile_app/cv_theme.dart';
 import 'package:mobile_app/locator.dart';
 import 'package:mobile_app/services/database_service.dart';
+import 'package:mobile_app/services/deep_link_manager.dart';
 import 'package:mobile_app/utils/router.dart';
 import 'package:theme_provider/theme_provider.dart';
 import 'package:mobile_app/ui/views/startup_view.dart';
@@ -20,6 +21,9 @@ Future<void> main() async {
 
   // Init Hive
   await locator<DatabaseService>().init();
+
+  locator<DeepLinkManager>().init();
+
   Get.put(LanguageController());
 
   runApp(const CircuitVerseMobile());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,7 +22,7 @@ Future<void> main() async {
   // Init Hive
   await locator<DatabaseService>().init();
 
-  locator<DeepLinkManager>().init();
+  await locator<DeepLinkManager>().init();
 
   Get.put(LanguageController());
 

--- a/lib/models/projects.dart
+++ b/lib/models/projects.dart
@@ -33,6 +33,26 @@ class Project {
             )
             : null,
   );
+
+  factory Project.idOnly(String id) => Project(
+    id: id,
+    type: 'project',
+    attributes: ProjectAttributes(
+      name: '',
+      projectAccessType: '',
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+      imagePreview: ImagePreview(url: ''),
+      view: 0,
+      tags: [],
+      isStarred: false,
+      authorName: '',
+      starsCount: 0,
+    ),
+    relationships: ProjectRelationships(
+      author: Author(data: AuthorData(id: '', type: 'user')),
+    ),
+  );
   Project({
     required this.id,
     required this.type,

--- a/lib/services/deep_link_manager.dart
+++ b/lib/services/deep_link_manager.dart
@@ -5,7 +5,6 @@ import 'package:get/get.dart';
 import 'package:mobile_app/locator.dart';
 import 'package:mobile_app/models/projects.dart';
 import 'package:mobile_app/services/API/projects_api.dart';
-import 'package:mobile_app/services/dialog_service.dart';
 import 'package:mobile_app/ui/views/projects/project_details_view.dart';
 import 'package:mobile_app/ui/views/simulator/simulator_view.dart';
 import 'package:mobile_app/utils/router.dart';
@@ -29,7 +28,9 @@ class DeepLinkManager {
       if (uri != null) {
         _handleLink(uri);
       }
-    } catch (e) {}
+    } catch (e) {
+      // ignore
+    }
   }
 
   void dispose() {

--- a/lib/services/deep_link_manager.dart
+++ b/lib/services/deep_link_manager.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+import 'package:app_links/app_links.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:mobile_app/locator.dart';
+import 'package:mobile_app/models/projects.dart';
+import 'package:mobile_app/services/API/projects_api.dart';
+import 'package:mobile_app/services/dialog_service.dart';
+import 'package:mobile_app/ui/views/projects/project_details_view.dart';
+import 'package:mobile_app/ui/views/simulator/simulator_view.dart';
+import 'package:mobile_app/utils/router.dart';
+import 'package:mobile_app/utils/snackbar_utils.dart';
+
+class DeepLinkManager {
+  final _appLinks = AppLinks();
+  StreamSubscription<Uri>? _linkSubscription;
+
+  void init() {
+    _checkInitialLink();
+
+    _linkSubscription = _appLinks.uriLinkStream.listen((uri) {
+      _handleLink(uri);
+    });
+  }
+
+  Future<void> _checkInitialLink() async {
+    try {
+      final uri = await _appLinks.getInitialLink();
+      if (uri != null) {
+        _handleLink(uri);
+      }
+    } catch (e) {}
+  }
+
+  void dispose() {
+    _linkSubscription?.cancel();
+  }
+
+  Future<void> _handleLink(Uri uri) async {
+    if (uri.host != 'circuitverse.org' && uri.host != 'www.circuitverse.org') {
+      return;
+    }
+
+    final pathSegments = uri.pathSegments;
+    if (pathSegments.isEmpty) return;
+
+    // /simulator/edit/:projectId OR /simulator/embed/:projectId
+    if (pathSegments.length >= 3 && pathSegments[0] == 'simulator') {
+      final mode = pathSegments[1]; // 'edit' or 'embed'
+      final projectId = pathSegments[2];
+
+      if (mode == 'edit' || mode == 'embed') {
+        final dummyProject = Project.idOnly(projectId);
+        final isEmbed = mode == 'embed';
+        Get.toNamed(
+          SimulatorView.id,
+          arguments: {'project': dummyProject, 'isEmbed': isEmbed},
+        );
+        return;
+      }
+    }
+
+    // /users/:userId/projects/:projectId
+    if (pathSegments.length >= 4 &&
+        pathSegments[0] == 'users' &&
+        pathSegments[2] == 'projects') {
+      final projectId = pathSegments[3];
+      _fetchAndNavigateToProject(projectId);
+      return;
+    }
+  }
+
+  Future<void> _fetchAndNavigateToProject(String projectId) async {
+    try {
+      final project = await locator<ProjectsApi>().getProjectDetails(projectId);
+
+      if (project != null) {
+        Get.offNamed(ProjectDetailsView.id, arguments: project);
+      }
+    } catch (e) {
+      SnackBarUtils.showDark('Error', 'Could not load project details.');
+    }
+  }
+
+  static Route<dynamic>? generateRoute(RouteSettings settings) {
+    final name = settings.name;
+    if (name != null) {
+      final uri = Uri.parse(name);
+      final segments = uri.pathSegments;
+      if (name.startsWith('/simulator/edit/') ||
+          name.startsWith('/simulator/embed/')) {
+        if (segments.length >= 3) {
+          final mode = segments[1];
+          final projectId = segments[2];
+          final dummyProject = Project.idOnly(projectId);
+          final isEmbed = mode == 'embed';
+
+          return CVRouter.buildRoute(
+            const SimulatorView(),
+            settings: RouteSettings(
+              name: SimulatorView.id,
+              arguments: {'project': dummyProject, 'isEmbed': isEmbed},
+            ),
+          );
+        }
+      }
+
+      // Pattern: /users/:userId/projects/:projectId
+      if (segments.length >= 4 &&
+          segments[0] == 'users' &&
+          segments[2] == 'projects') {
+        return CVRouter.buildRoute(
+          const Scaffold(body: Center(child: CircularProgressIndicator())),
+          settings: settings,
+        );
+      }
+    }
+    return null;
+  }
+}

--- a/lib/ui/views/groups/add_assignment_view.dart
+++ b/lib/ui/views/groups/add_assignment_view.dart
@@ -145,7 +145,7 @@ class _AddAssignmentViewState extends State<AddAssignmentView> {
         decoration: CVTheme.textFieldDecoration.copyWith(
           labelText: localizations.assignment_grading_scale,
         ),
-        value: _gradingScale,
+        initialValue: _gradingScale,
         onChanged: (String? value) {
           if (value == null) return;
           setState(() {

--- a/lib/ui/views/notifications/notifications_view.dart
+++ b/lib/ui/views/notifications/notifications_view.dart
@@ -135,7 +135,7 @@ class NotificationsView extends StatelessWidget {
                             ),
                           ),
                           // Fix: Use model.value but map it properly
-                          value:
+                          initialValue:
                               model.value == allDisplayText
                                   ? allValue
                                   : unreadValue,

--- a/lib/ui/views/projects/edit_project_view.dart
+++ b/lib/ui/views/projects/edit_project_view.dart
@@ -142,7 +142,7 @@ class _EditProjectViewState extends State<EditProjectView> {
         decoration: CVTheme.textFieldDecoration.copyWith(
           labelText: AppLocalizations.of(context)!.edit_project_access_type,
         ),
-        value: getCurrentValue(),
+        initialValue: getCurrentValue(),
         onChanged: (String? value) {
           if (value == null) return;
           setState(() {

--- a/lib/ui/views/simulator/simulator_view.dart
+++ b/lib/ui/views/simulator/simulator_view.dart
@@ -21,13 +21,22 @@ class _SimulatorViewState extends State<SimulatorView> {
 
   @override
   Widget build(BuildContext context) {
-    // Get the project argument if passed
-    final Project? project = Get.arguments as Project?;
+    final args = Get.arguments;
+    Project? project;
+    bool isEmbed = false;
+
+    if (args is Project) {
+      project = args;
+    } else if (args is Map) {
+      project = args['project'] as Project?;
+      isEmbed = args['isEmbed'] as bool? ?? false;
+    }
 
     return Scaffold(
       body: SafeArea(
         child: BaseView<SimulatorViewModel>(
-          onModelReady: (model) => model.onModelReady(project),
+          onModelReady:
+              (model) => model.onModelReady(project, isEmbed: isEmbed),
           onModelDestroy: (model) => model.onModelDestroy(),
           builder: (context, model, child) {
             return PopScope(

--- a/lib/utils/router.dart
+++ b/lib/utils/router.dart
@@ -15,6 +15,7 @@ import 'package:mobile_app/ui/views/groups/group_details_view.dart';
 import 'package:mobile_app/ui/views/groups/my_groups_view.dart';
 import 'package:mobile_app/ui/views/groups/new_group_view.dart';
 import 'package:mobile_app/ui/views/groups/update_assignment_view.dart';
+import 'package:mobile_app/services/deep_link_manager.dart';
 import 'package:mobile_app/ui/views/cv_landing_view.dart';
 import 'package:mobile_app/ui/views/ib/ib_landing_view.dart';
 import 'package:mobile_app/ui/views/profile/edit_profile_view.dart';
@@ -28,68 +29,73 @@ import 'package:mobile_app/ui/views/teachers/teachers_view.dart';
 
 class CVRouter {
   static Route<dynamic> generateRoute(RouteSettings settings) {
+    final deepLinkRoute = DeepLinkManager.generateRoute(settings);
+    if (deepLinkRoute != null) {
+      return deepLinkRoute;
+    }
+
     switch (settings.name) {
       case SignupView.id:
-        return _buildRoute(const SignupView());
+        return buildRoute(const SignupView());
       case LoginView.id:
-        return _buildRoute(const LoginView());
+        return buildRoute(const LoginView());
       case ForgotPasswordView.id:
-        return _buildRoute(const ForgotPasswordView());
+        return buildRoute(const ForgotPasswordView());
       case CVLandingView.id:
-        return _buildRoute(const CVLandingView());
+        return buildRoute(const CVLandingView());
       case SimulatorView.id:
-        final project = settings.arguments as Project?;
-        return _buildRoute(
+        final args = settings.arguments;
+        return buildRoute(
           const SimulatorView(),
-          settings: RouteSettings(name: SimulatorView.id, arguments: project),
+          settings: RouteSettings(name: SimulatorView.id, arguments: args),
         );
       case TeachersView.id:
-        return _buildRoute(const TeachersView());
+        return buildRoute(const TeachersView());
       case ContributorsView.id:
-        return _buildRoute(const ContributorsView());
+        return buildRoute(const ContributorsView());
       case AboutTosView.id:
-        return _buildRoute(const AboutTosView());
+        return buildRoute(const AboutTosView());
       case AboutPrivacyPolicyView.id:
-        return _buildRoute(const AboutPrivacyPolicyView());
+        return buildRoute(const AboutPrivacyPolicyView());
       case FeaturedProjectsView.id:
-        return _buildRoute(const FeaturedProjectsView());
+        return buildRoute(const FeaturedProjectsView());
       case ProfileView.id:
         var _userId = settings.arguments as String;
-        return _buildRoute(ProfileView(userId: _userId));
+        return buildRoute(ProfileView(userId: _userId));
       case EditProfileView.id:
-        return _buildRoute(const EditProfileView());
+        return buildRoute(const EditProfileView());
       case ProjectDetailsView.id:
         var _project = settings.arguments as Project;
-        return _buildRoute(ProjectDetailsView(project: _project));
+        return buildRoute(ProjectDetailsView(project: _project));
       case EditProjectView.id:
         var _project = settings.arguments as Project;
-        return _buildRoute(EditProjectView(project: _project));
+        return buildRoute(EditProjectView(project: _project));
       case MyGroupsView.id:
-        return _buildRoute(const MyGroupsView());
+        return buildRoute(const MyGroupsView());
       case GroupDetailsView.id:
         var group = settings.arguments as Group;
-        return _buildRoute(GroupDetailsView(group: group));
+        return buildRoute(GroupDetailsView(group: group));
       case NewGroupView.id:
-        return _buildRoute(const NewGroupView());
+        return buildRoute(const NewGroupView());
       case EditGroupView.id:
         var group = settings.arguments as Group;
-        return _buildRoute(EditGroupView(group: group));
+        return buildRoute(EditGroupView(group: group));
       case AssignmentDetailsView.id:
         var _assignment = settings.arguments as Assignment;
-        return _buildRoute(AssignmentDetailsView(assignment: _assignment));
+        return buildRoute(AssignmentDetailsView(assignment: _assignment));
       case AddAssignmentView.id:
         var _groupId = settings.arguments as String;
-        return _buildRoute(AddAssignmentView(groupId: _groupId));
+        return buildRoute(AddAssignmentView(groupId: _groupId));
       case UpdateAssignmentView.id:
         var _assignment = settings.arguments as Assignment;
-        return _buildRoute(UpdateAssignmentView(assignment: _assignment));
+        return buildRoute(UpdateAssignmentView(assignment: _assignment));
       case IbLandingView.id:
-        return _buildRoute(const IbLandingView());
+        return buildRoute(const IbLandingView());
       case ProjectPreviewFullScreen.id:
         var _project = settings.arguments as Project;
-        return _buildRoute(ProjectPreviewFullScreen(project: _project));
+        return buildRoute(ProjectPreviewFullScreen(project: _project));
       default:
-        return _buildRoute(
+        return buildRoute(
           Scaffold(
             body: Center(child: Text('No route defined for ${settings.name}')),
           ),
@@ -98,7 +104,7 @@ class CVRouter {
   }
 
   /// Premium fade + scale transition for optimal user experience
-  static PageRouteBuilder _buildRoute(Widget page, {RouteSettings? settings}) {
+  static PageRouteBuilder buildRoute(Widget page, {RouteSettings? settings}) {
     return PageRouteBuilder(
       settings: settings,
       transitionDuration: const Duration(milliseconds: 350),

--- a/lib/viewmodels/simulator/simulator_viewmodel.dart
+++ b/lib/viewmodels/simulator/simulator_viewmodel.dart
@@ -33,9 +33,13 @@ class SimulatorViewModel extends BaseModel {
 
   // Project to edit
   Project? _projectToEdit;
+  bool _isEmbed = false;
 
   String get url {
     if (_projectToEdit != null) {
+      if (_isEmbed) {
+        return '${EnvironmentConfig.CV_BASE_URL}/simulator/embed/${_projectToEdit!.id}';
+      }
       return '${EnvironmentConfig.CV_BASE_URL}/simulator/edit/${_projectToEdit!.id}';
     }
     return '${EnvironmentConfig.CV_BASE_URL}/simulator';
@@ -324,7 +328,8 @@ class SimulatorViewModel extends BaseModel {
     return false;
   }
 
-  void onModelReady([Project? project]) {
+  void onModelReady(Project? project, {bool isEmbed = false}) {
+    _isEmbed = isEmbed;
     if (project != null) {
       setProjectToEdit(project);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   markdown: any
   webview_flutter: 4.13.1
   flutter_quill: ^11.4.2
+  app_links: ^6.4.1
 dev_dependencies:
   mockito: ^5.4.4
   build_runner: ^2.4.13

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <app_links/app_links_plugin_c_api.h>
 #include <desktop_webview_window/desktop_webview_window_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_inappwebview_windows/flutter_inappwebview_windows_plugin_c_api.h>
@@ -16,6 +17,8 @@
 #include <window_to_front/window_to_front_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  AppLinksPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
   DesktopWebviewWindowPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DesktopWebviewWindowPlugin"));
   FileSelectorWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  app_links
   desktop_webview_window
   file_selector_windows
   flutter_inappwebview_windows


### PR DESCRIPTION
Fixes #482 

Describe the changes you have made in this PR 
- Added a Deep Link Manager using the app_links dependency.
- Now, when a user opens a supported (shareable) link and the app is already installed, it correctly opens inside the app instead of the browser.
- To make this work completely, we need to host our SHA key on the original website as required for app link verification. Related issue: https://github.com/CircuitVerse/CircuitVerse/issues/6720

Screenshots of the changes (If any) -
A demonstration video on how the links would work (in the video i have used adb for deeplinks but once assets is hosted, if we click on any link example: "https://circuitverse.org/simulator/embed/5010", it would open our app the same way as in video.

https://github.com/user-attachments/assets/26f0f409-d7c3-4b01-93cd-f88011b5ec4d

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deep linking: open projects and simulator views (including embed mode) directly from external links.

* **Improvements**
  * Simulator supports embed mode and forwards embed flag during navigation.
  * Routing now evaluates deep links before normal navigation; route handling expanded.

* **Bug Fixes**
  * Dropdown initialization updated for correct default selections on first render.

* **Chores**
  * Updated Flutter runtime to 3.35.
  * Added deep-linking dependency and platform/plugin registration (Android intent filters, desktop plugin).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->