### PR TITLE
chore(l10n): remove deprecated synthetic-package config

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -2,5 +2,5 @@ arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
 output-dir: lib/gen_l10n
-synthetic-package: false
+# synthetic-package: false
 preferred-supported-locales: ['en', 'ar', 'hi']


### PR DESCRIPTION
Fixes #

Describe the changes you have made in this PR -
Before:
l10n.yaml contained deprecated synthetic-package configuration which is no longer used by Flutter and causes build warnings.

After:
Removed deprecated synthetic-package configuration from l10n.yaml, eliminating build warnings and improving future compatibility and developer experience.

Screenshots of the changes (If any) -

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated localization configuration settings to rely on default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->