### PR TITLE
chore(l10n): remove deprecated synthetic-package option from l10n.yaml

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -2,5 +2,4 @@ arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
 output-dir: lib/gen_l10n
-synthetic-package: false
-preferred-supported-locales: ['en', 'ar', 'hi']
+preferred-supported-locales: ["en", "ar", "hi"]


### PR DESCRIPTION
### Summary
- Fixes #510 
- Removes the deprecated `synthetic-package: false` option from l10n.yaml that no longer has any effect in current Flutter versions and produces a deprecation warning during code generation.

### Changes

- l10n.yaml — removed `synthetic-package: false`

### 

Running any command that triggers localization generation (e.g., `flutter gen-l10n`, `flutter run`, `flutter build`) emitted the following console warning:

```
The argument "synthetic-package" no longer has any effect and should be removed.
See http://flutter.dev/to/flutter-gen-deprecation
```

The `synthetic-package` flag was introduced to control whether Flutter placed generated files inside a Dart synthetic package or a regular directory. This distinction was removed in newer Flutter tooling — `output-dir` alone now controls placement (gen_l10n in our case). The flag is now a no-op.

### Testing

- `flutter gen-l10n` runs cleanly with no warnings
- All localization files in gen_l10n are generated correctly
- `flutter analyze` passes




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated localization configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->