### PR TITLE
fix: resolve interactive-book rendering issue

### DIFF
--- a/lib/ui/views/ib/builders/ib_interaction_builder.dart
+++ b/lib/ui/views/ib/builders/ib_interaction_builder.dart
@@ -14,7 +14,7 @@ class IbInteractionBuilder extends MarkdownElementBuilder {
 
   @override
   Widget? visitElementAfter(md.Element element, TextStyle? preferredStyle) {
-    var id = element.textContent;
+    var id = element.attributes['id'] ?? '';
 
     return FutureBuilder<dynamic>(
       future: model.fetchHtmlInteraction(id),

--- a/lib/ui/views/ib/builders/ib_pop_quiz_builder.dart
+++ b/lib/ui/views/ib/builders/ib_pop_quiz_builder.dart
@@ -12,7 +12,7 @@ class IbPopQuizBuilder extends MarkdownElementBuilder {
 
   @override
   Widget visitElementAfter(md.Element element, TextStyle? preferredStyle) {
-    var _rawContent = element.textContent;
+    var _rawContent = element.attributes['content'] ?? '';
     var _popQuizQuestions = model.fetchPopQuiz(_rawContent);
 
     if (_popQuizQuestions == null) return Container();

--- a/lib/ui/views/ib/ib_page_view.dart
+++ b/lib/ui/views/ib/ib_page_view.dart
@@ -187,6 +187,7 @@ class _IbPageViewState extends State<IbPageView> {
         'iframe': IbWebViewBuilder(),
         'interaction': IbInteractionBuilder(model: _model),
         'quiz': IbPopQuizBuilder(context: context, model: _model),
+        'empty': IbEmptyBuilder(),
       },
       extensionSet: md.ExtensionSet(
         [
@@ -614,5 +615,12 @@ class CustomImageBuilder extends MarkdownElementBuilder {
         ),
       ),
     );
+  }
+}
+
+class IbEmptyBuilder extends MarkdownElementBuilder {
+  @override
+  Widget visitElementAfter(md.Element element, TextStyle? preferredStyle) {
+    return const SizedBox.shrink();
   }
 }

--- a/lib/ui/views/ib/syntaxes/ib_embed_syntax.dart
+++ b/lib/ui/views/ib/syntaxes/ib_embed_syntax.dart
@@ -8,7 +8,7 @@ class IbEmbedSyntax extends md.BlockSyntax {
     var text = parser.current;
     parser.advance();
 
-    return md.Element.text('iframe', text.content);
+    return md.Element('p', [md.Element.text('iframe', text.content)]);
   }
 
   @override

--- a/lib/ui/views/ib/syntaxes/ib_filter_syntax.dart
+++ b/lib/ui/views/ib/syntaxes/ib_filter_syntax.dart
@@ -6,7 +6,8 @@ class IbFilterSyntax extends md.BlockSyntax {
   @override
   md.Node? parse(md.BlockParser parser) {
     parser.advance();
-    return null;
+    // Return a block placeholder instead of null for stack safety
+    return md.Element('p', [md.Element.withTag('empty')]);
   }
 
   @override

--- a/lib/ui/views/ib/syntaxes/ib_liquid_syntax.dart
+++ b/lib/ui/views/ib/syntaxes/ib_liquid_syntax.dart
@@ -15,7 +15,7 @@ class IbLiquidSyntax extends md.BlockSyntax {
     if (tags[0] == 'include') {
       // chapter_toc include
       if (tags[1] == 'chapter_toc.html') {
-        node = md.Element.text('chapter_contents', '');
+        node = md.Element('p', [md.Element.withTag('chapter_contents')]);
       } else if (tags[1] == 'image.html' && tags.length >= 3) {
         // Images
         var url =
@@ -25,17 +25,22 @@ class IbLiquidSyntax extends md.BlockSyntax {
               r'''description=("|')([^"'\n\r]*)("|')''',
             ).firstMatch(match[1]!)![2];
 
-        node = md.Element.withTag('img');
-        node.attributes['src'] = '${EnvironmentConfig.IB_BASE_URL}$url';
-        node.attributes['alt'] = alt!;
+        var img = md.Element.withTag('img');
+        img.attributes['src'] = '${EnvironmentConfig.IB_BASE_URL}$url';
+        img.attributes['alt'] = alt!;
+        node = md.Element('p', [img]);
       } else {
         // Interactions using html
-        node = md.Element.text('interaction', tags[1]);
+        // Use attribute 'id' for data-via-attributes fix
+        var intNode = md.Element.withTag('interaction');
+        intNode.attributes['id'] = tags[1];
+        node = md.Element('p', [intNode]);
       }
     }
 
     parser.advance();
-    return node;
+    // Ensure all results are wrapped in p for paragraph protection
+    return node ?? md.Element('p', [md.Element.withTag('empty')]);
   }
 
   @override

--- a/lib/ui/views/ib/syntaxes/ib_md_tag_syntax.dart
+++ b/lib/ui/views/ib/syntaxes/ib_md_tag_syntax.dart
@@ -35,12 +35,17 @@ class IbMdTagSyntax extends md.BlockSyntax {
       } while (parser.next != null || !parser.isDone);
 
       _tagsStack.remove('.quiz');
-      return md.Element.text('quiz', quizContent);
+      // Wrap in p for paragraph protection and use attributes for data
+      return md.Element('p', [
+        md.Element.withTag('quiz')..attributes['content'] = quizContent,
+      ]);
     }
 
     parser.advance();
 
-    return null;
+    // Never return null after advancing the parser to keep it in sync
+    // Ensure placeholder is wrapped in p for block-level protection
+    return md.Element('p', [md.Element.withTag('empty')]);
   }
 
   @override


### PR DESCRIPTION
Fixes #496


Describe the changes you have made in this PR -


Summary
This PR addresses a critical assertion failure (_inlines.isEmpty) in the flutter_markdown builder that occurred during interactive scrolling in the Interactive Book section. The fix implements a robust, stack-safe architecture to ensure the markdown parser and builder remain perfectly synchronized.

The Problem
The diagnostic logs revealed that the _inlines.isEmpty error was caused by a fundamental leak in the markdown builder's inline stack. This happened when:

BlockSyntax nodes returned null or "Empty Text" children after advancing the parser.
Custom tags were interpreted as inlines instead of blocks, preventing the builder from clearing the inline stack correctly during its traversal.
The Solution: 100% Stack-Safe Architecture
1. Parser Synchronization
Updated BlockSyntax implementations (
IbMdTagSyntax, 
IbLiquidSyntax, 
IbFilterSyntax
) to never return null after advancing the parser. If content is skipped, the parser now returns an empty block node wrapped in a <p> tag. This prevents the parser from getting stuck or producing unbalanced nodes.

2. Paragraph Protection
Forced the MarkdownBuilder to follow its most stable and well-tested stack-clearing pathway by wrapping all custom block elements (like chapter_contents, interaction, and iframe) in native Paragraph (p) elements. Since p is a built-in block tag, it ensures the inline stack is cleared before proceeding to the next node.

3. Data-via-Attributes Refactoring
Refactored builders to read their IDs and content from attributes instead of text content. This allows the syntaxes to return nodes with strictly empty children lists, which prevents the builder from ever pushing a "leaky" entry onto the inline stack.

Interactions: Now use attributes['id'].
Pop Quizzes: Now use attributes['content'].
4. Invisible Empty Placeholder
Introduced a dedicated 
IbEmptyBuilder
 that renders SizedBox.shrink() for placeholder nodes (<empty>). This allows the parser to remain synchronized without impacting the UI layout.

Screenshots of the changes (If any) -
<img width="738" height="1600" alt="image" src="https://github.com/user-attachments/assets/7a404be7-b77f-43f0-92ac-1dd76ff6eee4" />


Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of content extraction for interactive elements and pop quiz features
  * Enhanced HTML structure handling for embedded content to ensure proper rendering and display
  * Strengthened parser robustness to gracefully handle missing or malformed content without interruption

<!-- end of auto-generated comment: release notes by coderabbit.ai -->