### PR TITLE
Fix logout navigation drawer UI not updating and navigate to Home screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+android/app/google-services.json

--- a/lib/viewmodels/cv_landing_viewmodel.dart
+++ b/lib/viewmodels/cv_landing_viewmodel.dart
@@ -41,7 +41,7 @@ class CVLandingViewModel extends BaseModel {
     _storage.isLoggedIn = false;
     _storage.currentUser = null;
     _storage.token = null;
-
+    _currentUser = null; 
     // Perform google signout if auth type is google..
     if (_storage.authType == AuthType.GOOGLE) {
       await _googleSignIn.signOut();
@@ -92,7 +92,12 @@ class CVLandingViewModel extends BaseModel {
 
     if (_dialogResponse?.confirmed ?? false) {
       onLogout();
+      // Close any open drawer/dialog
+      if (Get.isOverlaysOpen) {
+        Get.back();
+      }
       selectedIndex = 0;
+      Get.offAllNamed('/');
       SnackBarUtils.showDark(
         AppLocalizations.of(Get.context!)!.cv_logout_success,
         AppLocalizations.of(Get.context!)!.cv_logout_success_acknowledgement,


### PR DESCRIPTION
Fixes #520 

Describe the changes you have made in this PR -
Fixed the issue where logging out from the Navigation Drawer did not immediately navigate to the Home screen.
Updated the UI to instantly reflect the logged-out state, ensuring the previous user account is no longer visible.
Ensured proper navigation stack reset so that after logout, the app goes directly to the Home screen.

Screenshots of the changes (If any) -

https://github.com/user-attachments/assets/1ae40893-0345-4c0b-aa12-759957b10e04


Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout process to automatically close any open overlays or menus and return users to the home screen, ensuring a clean and consistent experience.

* **Chores**
  * Updated project configuration files to properly exclude sensitive build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->