### PR TITLE
added a snackbar for github oauth error handle for contributors

### DIFF
--- a/lib/ui/views/authentication/components/auth_options_view.dart
+++ b/lib/ui/views/authentication/components/auth_options_view.dart
@@ -37,9 +37,12 @@ class _AuthOptionsViewState extends State<AuthOptionsView> {
     if (_model.isSuccess(_model.GITHUB_OAUTH)) {
       await Get.offAllNamed(CVLandingView.id);
     } else if (_model.isError(_model.GITHUB_OAUTH)) {
-      SnackBarUtils.showDark(
-        'GitHub Authentication Error',
-        _model.errorMessageFor(_model.GITHUB_OAUTH),
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(_model.errorMessageFor(_model.GITHUB_OAUTH)),
+          backgroundColor: Colors.black.withValues(alpha: 0.8),
+        ),
       );
     }
   }

--- a/lib/viewmodels/authentication/auth_options_viewmodel.dart
+++ b/lib/viewmodels/authentication/auth_options_viewmodel.dart
@@ -61,6 +61,16 @@ class AuthOptionsViewModel extends BaseModel {
   }
 
   Future githubAuth({bool isSignUp = false}) async {
+    if (EnvironmentConfig.GITHUB_OAUTH_CLIENT_ID.isEmpty ||
+        EnvironmentConfig.GITHUB_OAUTH_CLIENT_SECRET.isEmpty) {
+      setStateFor(GITHUB_OAUTH, ViewState.Error);
+      setErrorMessageFor(
+        GITHUB_OAUTH,
+        'GitHub OAuth is not configured. Please set GITHUB_OAUTH_CLIENT_ID and GITHUB_OAUTH_CLIENT_SECRET.',
+      );
+      return;
+    }
+
     OAuth2Client _client = GitHubOAuth2Client(
       redirectUri: EnvironmentConfig.GITHUB_OAUTH_REDIRECT_URI,
       customUriScheme: 'circuitverse',


### PR DESCRIPTION
Fixes #500 (partially)

### Issue
Since the GitHub OAuth credentials are not configured, therefore on trying to login/signup through github results into no activity, which creates confusion for contributors.

### Changes Made
- added a **Snackbar message** to inform users when GitHub OAuth is not configured.
- this prevents confusion by clearly indicating why the GitHub login/signup action does not proceed.

## Screenshots
<img width="170" height="532" alt="Simulator Screenshot - iPhone 16e - 2026-03-04 at 18 20 04" src="https://github.com/user-attachments/assets/fc790d3f-81e9-4acb-8069-e2930f4e8342" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub OAuth error handling to prevent potential crashes when displaying error messages.
  * Added configuration validation for GitHub OAuth credentials that provides early error feedback if required credentials are not properly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->