### PR TITLE
Fix/forgot password error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+android/app/google-services.json

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -42,7 +42,7 @@
   "slack_channel": "قناة Slack",
   "open_source_title": "ساهم في المصادر المفتوحة",
   "how_to_support": "كيفية الدعم؟",
-  
+  "forgot_password_success": "تم إرسال تعليمات إعادة تعيين كلمة المرور بنجاح",
   "student_role": "أنا طالب",
   "student_support1": "أنشئ دوائر رائعة وشاركها على المنصة",
   "student_support2": "ابحث عن الأخطاء وأبلغ عنها. كن صياد أخطاء",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -93,7 +93,7 @@
   "forgot_password_instructions_sent_message": "Password reset instructions have been sent to your email",
   "forgot_password_error": "Error",
   "forgot_password_link": "Forgot Password?",
-
+  "forgot_password_success": "Reset instructions sent successfully.",
   "@login_view": {},
   "login_email": "Email",
   "login_email_validation_error": "Please enter a valid email",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -20,6 +20,7 @@
   "editor_picks_title": "एडिटर की पसंद",
   "editor_picks_subtitle": "ये सर्किट्स हमारे लेखकों द्वारा उनकी शानदारता के लिए चुने गए हैं",
   "explore_more_button": "और एक्सप्लोर करें",
+  "forgot_password_success": "पासवर्ड रीसेट निर्देश सफलतापूर्वक भेज दिए गए हैं",
   "@teachers_view": {},
   "teachers_title": "शिक्षक",
   "teachers_description": "CircuitVerse को कक्षा में उपयोग करने में बहुत आसान बनाया गया है। प्लेटफॉर्म में शिक्षकों की सहायता के लिए विशेषताएं हैं।",

--- a/lib/services/API/users_api.dart
+++ b/lib/services/API/users_api.dart
@@ -38,7 +38,7 @@ abstract class UsersApi {
     bool removePicture,
   );
 
-  Future<bool>? sendResetPasswordInstructions(String email);
+  Future<bool> sendResetPasswordInstructions(String email);
 }
 
 class HttpUsersApi implements UsersApi {
@@ -203,13 +203,15 @@ class HttpUsersApi implements UsersApi {
   }
 
   @override
-  Future<bool>? sendResetPasswordInstructions(String email) async {
+  Future<bool> sendResetPasswordInstructions(String email) async {
     var endpoint = '/password/forgot';
     var uri = EnvironmentConfig.CV_API_BASE_URL + endpoint;
     var json = {'email': email};
     try {
-      var jsonResponse = await ApiUtils.post(uri, headers: headers, body: json);
-      return jsonResponse['message'] is String;
+      // var jsonResponse = await ApiUtils.post(uri, headers: headers, body: json);
+      // return jsonResponse['message'] is String;
+      await ApiUtils.post(uri, headers: headers, body: json);
+      return true;
     } on NotFoundException {
       throw Failure(Constants.USER_NOT_FOUND);
     } on FormatException {

--- a/lib/ui/views/authentication/forgot_password_view.dart
+++ b/lib/ui/views/authentication/forgot_password_view.dart
@@ -26,7 +26,7 @@ class _ForgotPasswordViewState extends State<ForgotPasswordView> {
   late ForgotPasswordViewModel _model;
   final _formKey = GlobalKey<FormState>();
   late String _email;
-
+  String? _serverError;
   Widget _buildForgotPasswordImage() {
     return Container(
       width: MediaQuery.of(context).size.width,
@@ -38,19 +38,52 @@ class _ForgotPasswordViewState extends State<ForgotPasswordView> {
     );
   }
 
+  // Widget _buildEmailInput() {
+  //   return CVTextField(
+  //     label: AppLocalizations.of(context)!.forgot_password_email,
+  //     type: TextInputType.emailAddress,
+  //     validator:
+  //         (value) =>
+  //             Validators.isEmailValid(value)
+  //                 ? null
+  //                 : AppLocalizations.of(
+  //                   context,
+  //                 )!.forgot_password_email_validation_error,
+  //     onSaved: (value) => _email = value!.trim(),
+  //     action: TextInputAction.done,
+  //   );
+  // }
+
   Widget _buildEmailInput() {
-    return CVTextField(
-      label: AppLocalizations.of(context)!.forgot_password_email,
-      type: TextInputType.emailAddress,
-      validator:
-          (value) =>
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        CVTextField(
+          label: AppLocalizations.of(context)!.forgot_password_email,
+          type: TextInputType.emailAddress,
+          validator: (value) =>
               Validators.isEmailValid(value)
                   ? null
-                  : AppLocalizations.of(
-                    context,
-                  )!.forgot_password_email_validation_error,
-      onSaved: (value) => _email = value!.trim(),
-      action: TextInputAction.done,
+                  : AppLocalizations.of(context)!
+                      .forgot_password_email_validation_error,
+          onSaved: (value) => _email = value!.trim(),
+          action: TextInputAction.done,
+        ),
+
+        if (_serverError != null) ...[
+          const SizedBox(height: 6),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Text(
+              _serverError!,
+              style: const TextStyle(
+                color: Colors.red,
+                fontSize: 13,
+              ),
+            ),
+          ),
+        ],
+      ],
     );
   }
 
@@ -89,37 +122,29 @@ class _ForgotPasswordViewState extends State<ForgotPasswordView> {
   }
 
   Future<void> _validateAndSubmit() async {
-    var _dialogService = locator<DialogService>();
+    // var _dialogService = locator<DialogService>();
+    setState(() {_serverError = null;});
+    if (Validators.validateAndSaveForm(_formKey)){
+      FocusScope.of(context).unfocus();
+      final bool isSent =await _model.onForgotPassword(_email);
+      if (!mounted) return;
+      if (!isSent) {
+        setState(() {
+        _serverError = "This email is not registered.";
+      });
+      return;
+    }
 
-    if (Validators.validateAndSaveForm(_formKey) &&
-        !_model.isBusy(_model.SEND_RESET_INSTRUCTIONS)) {
-      FocusScope.of(context).requestFocus(FocusNode());
+    setState(() {
+      _serverError = null;
+    });
 
-      _dialogService.showCustomProgressDialog(
-        title:
-            AppLocalizations.of(context)!.forgot_password_sending_instructions,
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text("Reset instructions sent successfully."),
+        backgroundColor: Colors.green,
+        ),
       );
-
-      await _model.onForgotPassword(_email);
-
-      _dialogService.popDialog();
-
-      if (_model.isSuccess(_model.SEND_RESET_INSTRUCTIONS)) {
-        SnackBarUtils.showDark(
-          AppLocalizations.of(context)!.forgot_password_instructions_sent_title,
-          AppLocalizations.of(
-            context,
-          )!.forgot_password_instructions_sent_message,
-        );
-        await Future.delayed(const Duration(seconds: 1));
-        Get.back();
-      } else if (_model.isError(_model.SEND_RESET_INSTRUCTIONS)) {
-        SnackBarUtils.showDark(
-          AppLocalizations.of(context)!.forgot_password_error,
-          _model.errorMessageFor(_model.SEND_RESET_INSTRUCTIONS),
-        );
-        _formKey.currentState?.reset();
-      }
     }
   }
 

--- a/lib/ui/views/authentication/forgot_password_view.dart
+++ b/lib/ui/views/authentication/forgot_password_view.dart
@@ -87,6 +87,7 @@ class _ForgotPasswordViewState extends State<ForgotPasswordView> {
     );
   }
 
+
   Widget _buildSendInstructionsButton() {
     return Container(
       padding: const EdgeInsetsDirectional.symmetric(horizontal: 16),
@@ -123,26 +124,22 @@ class _ForgotPasswordViewState extends State<ForgotPasswordView> {
 
   Future<void> _validateAndSubmit() async {
     // var _dialogService = locator<DialogService>();
-    setState(() {_serverError = null;});
+    setState(() => _serverError = null);
     if (Validators.validateAndSaveForm(_formKey)){
       FocusScope.of(context).unfocus();
-      final bool isSent =await _model.onForgotPassword(_email);
+      final bool isSent = await _model.onForgotPassword(_email);
+
       if (!mounted) return;
       if (!isSent) {
         setState(() {
-        _serverError = "This email is not registered.";
-      });
-      return;
-    }
-
-    setState(() {
-      _serverError = null;
-    });
-
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text("Reset instructions sent successfully."),
-        backgroundColor: Colors.green,
+          _serverError = _model.errorMessageFor(_model.SEND_RESET_INSTRUCTIONS);
+        });
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(AppLocalizations.of(context)!.forgot_password_success,),
+          backgroundColor: Colors.green,
         ),
       );
     }

--- a/lib/ui/views/authentication/forgot_password_view.dart
+++ b/lib/ui/views/authentication/forgot_password_view.dart
@@ -124,7 +124,7 @@ class _ForgotPasswordViewState extends State<ForgotPasswordView> {
 
   Future<void> _validateAndSubmit() async {
     // var _dialogService = locator<DialogService>();
-    setState(() => _serverError = null);
+    setState((){ _serverError = null;});
     if (Validators.validateAndSaveForm(_formKey)){
       FocusScope.of(context).unfocus();
       final bool isSent = await _model.onForgotPassword(_email);

--- a/lib/viewmodels/authentication/forgot_password_viewmodel.dart
+++ b/lib/viewmodels/authentication/forgot_password_viewmodel.dart
@@ -23,7 +23,7 @@ class ForgotPasswordViewModel extends BaseModel {
         setStateFor(SEND_RESET_INSTRUCTIONS, ViewState.Error);
         setErrorMessageFor(
           SEND_RESET_INSTRUCTIONS,
-          "Instructions couldn't be sent! Tnvalid Email",
+          "Instructions couldn't be sent! Invalid Email",
         );
       }
       return isSent;

--- a/lib/viewmodels/authentication/forgot_password_viewmodel.dart
+++ b/lib/viewmodels/authentication/forgot_password_viewmodel.dart
@@ -13,22 +13,32 @@ class ForgotPasswordViewModel extends BaseModel {
   Future onForgotPassword(String email) async {
     setStateFor(SEND_RESET_INSTRUCTIONS, ViewState.Busy);
     try {
-      var _areInstructionsSent = await _usersApi.sendResetPasswordInstructions(
+      final bool isSent = await _usersApi.sendResetPasswordInstructions(
         email,
       );
 
-      if (_areInstructionsSent ?? false) {
+      if (isSent) {
         setStateFor(SEND_RESET_INSTRUCTIONS, ViewState.Success);
       } else {
         setStateFor(SEND_RESET_INSTRUCTIONS, ViewState.Error);
         setErrorMessageFor(
           SEND_RESET_INSTRUCTIONS,
-          "Instructions couldn't be sent!",
+          "Instructions couldn't be sent! Tnvalid Email",
         );
       }
+      return isSent;
     } on Failure catch (f) {
       setStateFor(SEND_RESET_INSTRUCTIONS, ViewState.Error);
       setErrorMessageFor(SEND_RESET_INSTRUCTIONS, f.message);
+      return false;
+    }
+    catch(_){
+      setStateFor(SEND_RESET_INSTRUCTIONS, ViewState.Error);
+    setErrorMessageFor(
+      SEND_RESET_INSTRUCTIONS,
+      "Something went wrong",
+    );
+    return false;
     }
   }
 }

--- a/lib/viewmodels/cv_landing_viewmodel.dart
+++ b/lib/viewmodels/cv_landing_viewmodel.dart
@@ -6,6 +6,7 @@ import 'package:mobile_app/models/user.dart';
 import 'package:mobile_app/services/dialog_service.dart';
 import 'package:mobile_app/services/local_storage_service.dart';
 import 'package:mobile_app/gen_l10n/app_localizations.dart';
+import 'package:mobile_app/ui/views/cv_landing_view.dart';
 import 'package:mobile_app/utils/snackbar_utils.dart';
 import 'package:mobile_app/viewmodels/base_viewmodel.dart';
 import 'package:mobile_app/viewmodels/notifications/notifications_viewmodel.dart';
@@ -97,7 +98,7 @@ class CVLandingViewModel extends BaseModel {
         Get.back();
       }
       selectedIndex = 0;
-      Get.offAllNamed('/');
+      Get.offAllNamed(CVLandingView.id);
       SnackBarUtils.showDark(
         AppLocalizations.of(Get.context!)!.cv_logout_success,
         AppLocalizations.of(Get.context!)!.cv_logout_success_acknowledgement,

--- a/lib/viewmodels/cv_landing_viewmodel.dart
+++ b/lib/viewmodels/cv_landing_viewmodel.dart
@@ -41,7 +41,7 @@ class CVLandingViewModel extends BaseModel {
     _storage.isLoggedIn = false;
     _storage.currentUser = null;
     _storage.token = null;
-
+    _currentUser = null; 
     // Perform google signout if auth type is google..
     if (_storage.authType == AuthType.GOOGLE) {
       await _googleSignIn.signOut();
@@ -92,7 +92,12 @@ class CVLandingViewModel extends BaseModel {
 
     if (_dialogResponse?.confirmed ?? false) {
       onLogout();
+      // Close any open drawer/dialog
+      if (Get.isOverlaysOpen) {
+        Get.back();
+      }
       selectedIndex = 0;
+      Get.offAllNamed('/');
       SnackBarUtils.showDark(
         AppLocalizations.of(Get.context!)!.cv_logout_success,
         AppLocalizations.of(Get.context!)!.cv_logout_success_acknowledgement,


### PR DESCRIPTION
Fixes #498 

Describe the changes you have made in this PR -

Improved the Forgot Password flow by adding proper user feedback for both success and error scenarios.
Displays a confirmation message when reset instructions are successfully sent to a registered email.
Displays an error message ("Invalid email") when the entered email is not registered.
Ensures clear and immediate visual feedback below the email field in red color for error cases.
Improved error handling logic in UsersApi, ForgotPasswordViewModel, and the Forgot Password UI.

Screenshots of the changes (If any) -
![1](https://github.com/user-attachments/assets/d0df93e1-f014-4d8b-8f08-afb6dce93424)
![2](https://github.com/user-attachments/assets/a327a261-5959-4ca2-9009-3334611d1460)

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forgot-password flow: shows inline server errors and returns clear failure/success states.
  * Replaced dialog flow with a success snackbar after sending reset instructions.
  * Fixed logout flow to close overlays, reset state, and navigate cleanly.

* **New Features**
  * Added localized "reset instructions sent" message (Arabic, English, Hindi).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->