### PR TITLE
Feature/offline support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+android/app/google-services.json

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -42,7 +42,7 @@
   "slack_channel": "قناة Slack",
   "open_source_title": "ساهم في المصادر المفتوحة",
   "how_to_support": "كيفية الدعم؟",
-  
+  "forgot_password_success": "تم إرسال تعليمات إعادة تعيين كلمة المرور بنجاح",
   "student_role": "أنا طالب",
   "student_support1": "أنشئ دوائر رائعة وشاركها على المنصة",
   "student_support2": "ابحث عن الأخطاء وأبلغ عنها. كن صياد أخطاء",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -93,7 +93,7 @@
   "forgot_password_instructions_sent_message": "Password reset instructions have been sent to your email",
   "forgot_password_error": "Error",
   "forgot_password_link": "Forgot Password?",
-
+  "forgot_password_success": "Reset instructions sent successfully.",
   "@login_view": {},
   "login_email": "Email",
   "login_email_validation_error": "Please enter a valid email",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -292,6 +292,7 @@
   "ib_home": "Interactive Book Home",
   "ib_loading_chapters": "Loading Chapters...",
   "ib_show_toc": "Show Table of Contents",
+  "ib_page_offline_available": "Offline Available",
 
   "@ib_page_view": {},
   "ib_page_copyright_notice": "Copyright © 2021 Contributors to CircuitVerse. Distributed under a [CC-by-sa] license.",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -20,6 +20,7 @@
   "editor_picks_title": "एडिटर की पसंद",
   "editor_picks_subtitle": "ये सर्किट्स हमारे लेखकों द्वारा उनकी शानदारता के लिए चुने गए हैं",
   "explore_more_button": "और एक्सप्लोर करें",
+  "forgot_password_success": "पासवर्ड रीसेट निर्देश सफलतापूर्वक भेज दिए गए हैं",
   "@teachers_view": {},
   "teachers_title": "शिक्षक",
   "teachers_description": "CircuitVerse को कक्षा में उपयोग करने में बहुत आसान बनाया गया है। प्लेटफॉर्म में शिक्षकों की सहायता के लिए विशेषताएं हैं।",

--- a/lib/services/API/users_api.dart
+++ b/lib/services/API/users_api.dart
@@ -38,7 +38,7 @@ abstract class UsersApi {
     bool removePicture,
   );
 
-  Future<bool>? sendResetPasswordInstructions(String email);
+  Future<bool> sendResetPasswordInstructions(String email);
 }
 
 class HttpUsersApi implements UsersApi {
@@ -203,13 +203,15 @@ class HttpUsersApi implements UsersApi {
   }
 
   @override
-  Future<bool>? sendResetPasswordInstructions(String email) async {
+  Future<bool> sendResetPasswordInstructions(String email) async {
     var endpoint = '/password/forgot';
     var uri = EnvironmentConfig.CV_API_BASE_URL + endpoint;
     var json = {'email': email};
     try {
-      var jsonResponse = await ApiUtils.post(uri, headers: headers, body: json);
-      return jsonResponse['message'] is String;
+      // var jsonResponse = await ApiUtils.post(uri, headers: headers, body: json);
+      // return jsonResponse['message'] is String;
+      await ApiUtils.post(uri, headers: headers, body: json);
+      return true;
     } on NotFoundException {
       throw Failure(Constants.USER_NOT_FOUND);
     } on FormatException {

--- a/lib/services/ib_offline_service.dart
+++ b/lib/services/ib_offline_service.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
+
+class IbOfflineService {
+
+  Future<String> _getPath(String chapterId) async {
+    final dir = await getApplicationDocumentsDirectory();
+    final safeId = chapterId.replaceAll("/", "_");
+    return "${dir.path}/ib_$safeId";
+  }
+
+  Future<void> saveChapter(String chapterId, String data) async {
+    try{
+      final path = await _getPath(chapterId);
+      final file = File(path);
+      await file.writeAsString(data);
+    }
+    catch(e){
+      print("Offline save error: $e");
+    }
+  }
+
+  Future<String?> loadChapter(String chapterId) async {
+    try{
+      final path = await _getPath(chapterId);
+      final file = File(path);  
+      if (await file.exists()) {
+        return await file.readAsString();
+      }
+    }
+    catch(e){
+      print("Offline load error: $e");
+    }
+    return null;
+  }
+
+  // Future<bool> isDownloaded(String chapterId) async {
+  //   final path = await _getPath(chapterId);
+  //   return File(path).exists();
+  // }
+  
+}

--- a/lib/ui/views/authentication/forgot_password_view.dart
+++ b/lib/ui/views/authentication/forgot_password_view.dart
@@ -26,7 +26,7 @@ class _ForgotPasswordViewState extends State<ForgotPasswordView> {
   late ForgotPasswordViewModel _model;
   final _formKey = GlobalKey<FormState>();
   late String _email;
-
+  String? _serverError;
   Widget _buildForgotPasswordImage() {
     return Container(
       width: MediaQuery.of(context).size.width,
@@ -38,19 +38,52 @@ class _ForgotPasswordViewState extends State<ForgotPasswordView> {
     );
   }
 
+  // Widget _buildEmailInput() {
+  //   return CVTextField(
+  //     label: AppLocalizations.of(context)!.forgot_password_email,
+  //     type: TextInputType.emailAddress,
+  //     validator:
+  //         (value) =>
+  //             Validators.isEmailValid(value)
+  //                 ? null
+  //                 : AppLocalizations.of(
+  //                   context,
+  //                 )!.forgot_password_email_validation_error,
+  //     onSaved: (value) => _email = value!.trim(),
+  //     action: TextInputAction.done,
+  //   );
+  // }
+
   Widget _buildEmailInput() {
-    return CVTextField(
-      label: AppLocalizations.of(context)!.forgot_password_email,
-      type: TextInputType.emailAddress,
-      validator:
-          (value) =>
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        CVTextField(
+          label: AppLocalizations.of(context)!.forgot_password_email,
+          type: TextInputType.emailAddress,
+          validator: (value) =>
               Validators.isEmailValid(value)
                   ? null
-                  : AppLocalizations.of(
-                    context,
-                  )!.forgot_password_email_validation_error,
-      onSaved: (value) => _email = value!.trim(),
-      action: TextInputAction.done,
+                  : AppLocalizations.of(context)!
+                      .forgot_password_email_validation_error,
+          onSaved: (value) => _email = value!.trim(),
+          action: TextInputAction.done,
+        ),
+
+        if (_serverError != null) ...[
+          const SizedBox(height: 6),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Text(
+              _serverError!,
+              style: const TextStyle(
+                color: Colors.red,
+                fontSize: 13,
+              ),
+            ),
+          ),
+        ],
+      ],
     );
   }
 
@@ -89,37 +122,29 @@ class _ForgotPasswordViewState extends State<ForgotPasswordView> {
   }
 
   Future<void> _validateAndSubmit() async {
-    var _dialogService = locator<DialogService>();
+    // var _dialogService = locator<DialogService>();
+    setState(() {_serverError = null;});
+    if (Validators.validateAndSaveForm(_formKey)){
+      FocusScope.of(context).unfocus();
+      final bool isSent =await _model.onForgotPassword(_email);
+      if (!mounted) return;
+      if (!isSent) {
+        setState(() {
+        _serverError = "This email is not registered.";
+      });
+      return;
+    }
 
-    if (Validators.validateAndSaveForm(_formKey) &&
-        !_model.isBusy(_model.SEND_RESET_INSTRUCTIONS)) {
-      FocusScope.of(context).requestFocus(FocusNode());
+    setState(() {
+      _serverError = null;
+    });
 
-      _dialogService.showCustomProgressDialog(
-        title:
-            AppLocalizations.of(context)!.forgot_password_sending_instructions,
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text("Reset instructions sent successfully."),
+        backgroundColor: Colors.green,
+        ),
       );
-
-      await _model.onForgotPassword(_email);
-
-      _dialogService.popDialog();
-
-      if (_model.isSuccess(_model.SEND_RESET_INSTRUCTIONS)) {
-        SnackBarUtils.showDark(
-          AppLocalizations.of(context)!.forgot_password_instructions_sent_title,
-          AppLocalizations.of(
-            context,
-          )!.forgot_password_instructions_sent_message,
-        );
-        await Future.delayed(const Duration(seconds: 1));
-        Get.back();
-      } else if (_model.isError(_model.SEND_RESET_INSTRUCTIONS)) {
-        SnackBarUtils.showDark(
-          AppLocalizations.of(context)!.forgot_password_error,
-          _model.errorMessageFor(_model.SEND_RESET_INSTRUCTIONS),
-        );
-        _formKey.currentState?.reset();
-      }
     }
   }
 

--- a/lib/ui/views/authentication/forgot_password_view.dart
+++ b/lib/ui/views/authentication/forgot_password_view.dart
@@ -87,6 +87,7 @@ class _ForgotPasswordViewState extends State<ForgotPasswordView> {
     );
   }
 
+
   Widget _buildSendInstructionsButton() {
     return Container(
       padding: const EdgeInsetsDirectional.symmetric(horizontal: 16),
@@ -123,26 +124,22 @@ class _ForgotPasswordViewState extends State<ForgotPasswordView> {
 
   Future<void> _validateAndSubmit() async {
     // var _dialogService = locator<DialogService>();
-    setState(() {_serverError = null;});
+    setState(() => _serverError = null);
     if (Validators.validateAndSaveForm(_formKey)){
       FocusScope.of(context).unfocus();
-      final bool isSent =await _model.onForgotPassword(_email);
+      final bool isSent = await _model.onForgotPassword(_email);
+
       if (!mounted) return;
       if (!isSent) {
         setState(() {
-        _serverError = "This email is not registered.";
-      });
-      return;
-    }
-
-    setState(() {
-      _serverError = null;
-    });
-
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text("Reset instructions sent successfully."),
-        backgroundColor: Colors.green,
+          _serverError = _model.errorMessageFor(_model.SEND_RESET_INSTRUCTIONS);
+        });
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(AppLocalizations.of(context)!.forgot_password_success,),
+          backgroundColor: Colors.green,
         ),
       );
     }

--- a/lib/ui/views/ib/ib_page_view.dart
+++ b/lib/ui/views/ib/ib_page_view.dart
@@ -35,7 +35,6 @@ import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:showcaseview/showcaseview.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 import 'package:mobile_app/gen_l10n/app_localizations.dart';
-
 import '../../../viewmodels/ib/ib_floating_button_state.dart';
 
 typedef TocCallback = void Function(Function?);
@@ -75,10 +74,18 @@ class _IbPageViewState extends State<IbPageView> {
   final Map<String, int> _slugMap = {};
 
   @override
+  void dispose() {
+    _slugMap.clear();
+    _hideButtonController.dispose();
+    super.dispose();
+  }
+
+  @override
   void initState() {
-    _ibFloatingButtonState = IbFloatingButtonState();
     super.initState();
-    _showCaseWidgetState = ShowCaseWidget.of(context);
+    _ibFloatingButtonState = IbFloatingButtonState();
+    // super.initState();
+    // _showCaseWidgetState = ShowCaseWidget.of(context);
     _landingModel = context.read<IbLandingViewModel>();
     _hideButtonController = AutoScrollController(axis: Axis.vertical);
     _hideButtonController.addListener(() {
@@ -107,13 +114,20 @@ class _IbPageViewState extends State<IbPageView> {
   }
 
   Future _scrollToWidget(String slug) async {
+    if(!mounted) return;
+    if (!_hideButtonController.hasClients) return;
     if (_slugMap.containsKey(slug)) {
-      await _hideButtonController.scrollToIndex(
-        _slugMap[slug]!,
-        preferPosition: AutoScrollPosition.begin,
-      );
-    } else {
-      debugPrint('[IB]: $slug not present in map');
+      try{
+        await Future.delayed(const Duration(milliseconds: 50));
+        if (!mounted) return;
+        await _hideButtonController.scrollToIndex(
+          _slugMap[slug]!,
+          preferPosition: AutoScrollPosition.begin,
+        );
+      }
+      catch(e){
+        debugPrint("Scroll Skipped: $e");
+      }
     }
   }
 
@@ -361,7 +375,7 @@ class _IbPageViewState extends State<IbPageView> {
                 duration: const Duration(milliseconds: 500),
                 opacity: _ibFloatingButtonState.isVisible ? 1.0 : 0.0,
                 child: FloatingActionButton(
-                  heroTag: 'previousPage',
+                  heroTag: 'previousPage_${widget.chapter.id}',
                   mini: true,
                   backgroundColor: Theme.of(context).primaryIconTheme.color,
                   onPressed:
@@ -404,7 +418,7 @@ class _IbPageViewState extends State<IbPageView> {
                 duration: const Duration(milliseconds: 500),
                 opacity: _ibFloatingButtonState.isVisible ? 1.0 : 0.0,
                 child: FloatingActionButton(
-                  heroTag: 'nextPage',
+                  heroTag: 'nextPage_${widget.chapter.id}',
                   mini: true,
                   backgroundColor: Theme.of(context).primaryIconTheme.color,
                   onPressed:
@@ -468,23 +482,30 @@ class _IbPageViewState extends State<IbPageView> {
     return contents;
   }
 
-  @override
-  void dispose() {
-    _hideButtonController.dispose();
-    super.dispose();
-  }
+  // @override
+  // void dispose() {
+  //   _hideButtonController.dispose();
+  //   super.dispose();
+  // }
 
   @override
   Widget build(BuildContext context) {
     return BaseView<IbPageViewModel>(
       onModelReady: (model) {
         _model = model;
+        // model.fetchPageData(id: widget.chapter.id);
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
         model.fetchPageData(id: widget.chapter.id);
-        model.showCase(
-          _showCaseWidgetState,
-          widget.showCase,
-          widget.globalKeysMap,
-        );
+        Future.delayed(const Duration(milliseconds: 300), () {
+          if (!mounted) return;
+          model.showCase(
+            _showCaseWidgetState,
+            widget.showCase,
+            widget.globalKeysMap,
+          );
+        });
+      });
       },
       builder: (context, model, child) {
         if (_model.isSuccess(_model.IB_FETCH_PAGE_DATA) &&
@@ -503,7 +524,24 @@ class _IbPageViewState extends State<IbPageView> {
                 padding: const EdgeInsets.all(16),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
-                  children: _buildPageContent(model.pageData),
+                  // children: _buildPageContent(model.pageData),
+                  children: [
+                  if(model.isOfflineAvailable)
+                    Container(
+                      margin: const EdgeInsets.only(bottom: 10),
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: Colors.green,
+                        borderRadius: BorderRadius.circular(5),
+                      ),
+                      child: const Text(
+                        "Offline Available",
+                        style: TextStyle(color: Colors.white, fontSize: 12),
+                      ),
+                    ),
+
+                    ..._buildPageContent(model.pageData),
+                  ],
                 ),
               ),
             ),

--- a/lib/ui/views/ib/ib_page_view.dart
+++ b/lib/ui/views/ib/ib_page_view.dart
@@ -534,8 +534,8 @@ class _IbPageViewState extends State<IbPageView> {
                         color: Colors.green,
                         borderRadius: BorderRadius.circular(5),
                       ),
-                      child: const Text(
-                        "Offline Available",
+                      child:Text(
+                        AppLocalizations.of(context)!.ib_page_offline_available,
                         style: TextStyle(color: Colors.white, fontSize: 12),
                       ),
                     ),

--- a/lib/ui/views/ib/ib_page_view.dart
+++ b/lib/ui/views/ib/ib_page_view.dart
@@ -494,17 +494,16 @@ class _IbPageViewState extends State<IbPageView> {
       onModelReady: (model) {
         _model = model;
         // model.fetchPageData(id: widget.chapter.id);
-        WidgetsBinding.instance.addPostFrameCallback((_) {
+        WidgetsBinding.instance.addPostFrameCallback((_) async{
         if (!mounted) return;
-        model.fetchPageData(id: widget.chapter.id);
-        Future.delayed(const Duration(milliseconds: 300), () {
-          if (!mounted) return;
-          model.showCase(
-            _showCaseWidgetState,
-            widget.showCase,
-            widget.globalKeysMap,
-          );
-        });
+        await model.fetchPageData(id: widget.chapter.id);
+        // Future.delayed(const Duration(milliseconds: 300), () {
+        if (!mounted) return;
+        model.showCase(
+          _showCaseWidgetState,
+          widget.showCase,
+          widget.globalKeysMap,
+        );
       });
       },
       builder: (context, model, child) {

--- a/lib/utils/network_utils.dart
+++ b/lib/utils/network_utils.dart
@@ -1,0 +1,8 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+class NetworkUtils {
+  static Future<bool> isOnline() async {
+    final result = await Connectivity().checkConnectivity();
+    return result != ConnectivityResult.none;
+  }
+}

--- a/lib/viewmodels/authentication/forgot_password_viewmodel.dart
+++ b/lib/viewmodels/authentication/forgot_password_viewmodel.dart
@@ -23,7 +23,7 @@ class ForgotPasswordViewModel extends BaseModel {
         setStateFor(SEND_RESET_INSTRUCTIONS, ViewState.Error);
         setErrorMessageFor(
           SEND_RESET_INSTRUCTIONS,
-          "Instructions couldn't be sent! Tnvalid Email",
+          "Instructions couldn't be sent! Invalid Email",
         );
       }
       return isSent;

--- a/lib/viewmodels/authentication/forgot_password_viewmodel.dart
+++ b/lib/viewmodels/authentication/forgot_password_viewmodel.dart
@@ -13,22 +13,32 @@ class ForgotPasswordViewModel extends BaseModel {
   Future onForgotPassword(String email) async {
     setStateFor(SEND_RESET_INSTRUCTIONS, ViewState.Busy);
     try {
-      var _areInstructionsSent = await _usersApi.sendResetPasswordInstructions(
+      final bool isSent = await _usersApi.sendResetPasswordInstructions(
         email,
       );
 
-      if (_areInstructionsSent ?? false) {
+      if (isSent) {
         setStateFor(SEND_RESET_INSTRUCTIONS, ViewState.Success);
       } else {
         setStateFor(SEND_RESET_INSTRUCTIONS, ViewState.Error);
         setErrorMessageFor(
           SEND_RESET_INSTRUCTIONS,
-          "Instructions couldn't be sent!",
+          "Instructions couldn't be sent! Tnvalid Email",
         );
       }
+      return isSent;
     } on Failure catch (f) {
       setStateFor(SEND_RESET_INSTRUCTIONS, ViewState.Error);
       setErrorMessageFor(SEND_RESET_INSTRUCTIONS, f.message);
+      return false;
+    }
+    catch(_){
+      setStateFor(SEND_RESET_INSTRUCTIONS, ViewState.Error);
+    setErrorMessageFor(
+      SEND_RESET_INSTRUCTIONS,
+      "Something went wrong",
+    );
+    return false;
     }
   }
 }

--- a/lib/viewmodels/cv_landing_viewmodel.dart
+++ b/lib/viewmodels/cv_landing_viewmodel.dart
@@ -6,6 +6,7 @@ import 'package:mobile_app/models/user.dart';
 import 'package:mobile_app/services/dialog_service.dart';
 import 'package:mobile_app/services/local_storage_service.dart';
 import 'package:mobile_app/gen_l10n/app_localizations.dart';
+import 'package:mobile_app/ui/views/cv_landing_view.dart';
 import 'package:mobile_app/utils/snackbar_utils.dart';
 import 'package:mobile_app/viewmodels/base_viewmodel.dart';
 import 'package:mobile_app/viewmodels/notifications/notifications_viewmodel.dart';
@@ -97,7 +98,7 @@ class CVLandingViewModel extends BaseModel {
         Get.back();
       }
       selectedIndex = 0;
-      Get.offAllNamed('/');
+      Get.offAllNamed(CVLandingView.id);
       SnackBarUtils.showDark(
         AppLocalizations.of(Get.context!)!.cv_logout_success,
         AppLocalizations.of(Get.context!)!.cv_logout_success_acknowledgement,

--- a/lib/viewmodels/cv_landing_viewmodel.dart
+++ b/lib/viewmodels/cv_landing_viewmodel.dart
@@ -41,7 +41,7 @@ class CVLandingViewModel extends BaseModel {
     _storage.isLoggedIn = false;
     _storage.currentUser = null;
     _storage.token = null;
-
+    _currentUser = null; 
     // Perform google signout if auth type is google..
     if (_storage.authType == AuthType.GOOGLE) {
       await _googleSignIn.signOut();
@@ -92,7 +92,12 @@ class CVLandingViewModel extends BaseModel {
 
     if (_dialogResponse?.confirmed ?? false) {
       onLogout();
+      // Close any open drawer/dialog
+      if (Get.isOverlaysOpen) {
+        Get.back();
+      }
       selectedIndex = 0;
+      Get.offAllNamed('/');
       SnackBarUtils.showDark(
         AppLocalizations.of(Get.context!)!.cv_logout_success,
         AppLocalizations.of(Get.context!)!.cv_logout_success_acknowledgement,

--- a/lib/viewmodels/cv_landing_viewmodel.dart
+++ b/lib/viewmodels/cv_landing_viewmodel.dart
@@ -94,7 +94,7 @@ class CVLandingViewModel extends BaseModel {
     if (_dialogResponse?.confirmed ?? false) {
       onLogout();
       // Close any open drawer/dialog
-      if (Get.isOverlaysOpen) {
+      if (Get.isDialogOpen ?? false) {
         Get.back();
       }
       selectedIndex = 0;

--- a/lib/viewmodels/ib/ib_page_viewmodel.dart
+++ b/lib/viewmodels/ib/ib_page_viewmodel.dart
@@ -95,6 +95,8 @@ class IbPageViewModel extends BaseModel {
         pageUrl: "",
         title: "Offline Chapter",
         content: [IbMd(content: cachedMarkdown)],
+        tableOfContents: _pageData?.tableOfContents,
+        chapterOfContents: _pageData?.chapterOfContents,
       );
 
       isOfflineAvailable = true;

--- a/lib/viewmodels/ib/ib_page_viewmodel.dart
+++ b/lib/viewmodels/ib/ib_page_viewmodel.dart
@@ -69,17 +69,16 @@ class IbPageViewModel extends BaseModel {
       }
     }
 
+    
     if (markdown.isNotEmpty) {
-      await _offlineService.saveChapter(id, markdown);
-      if (markdown.isNotEmpty) {
-        try {
-          await _offlineService.saveChapter(id, markdown);
-          isOfflineAvailable = true;
-        } catch (_) {
-          isOfflineAvailable = false;
-        }
+      try {
+        await _offlineService.saveChapter(id, markdown);
+        isOfflineAvailable = true;
+      } catch (_) {
+        isOfflineAvailable = false;
       }
     }
+    
 
     // setStateFor(IB_FETCH_PAGE_DATA, ViewState.Success);
     if (!disposed) {

--- a/lib/viewmodels/ib/ib_page_viewmodel.dart
+++ b/lib/viewmodels/ib/ib_page_viewmodel.dart
@@ -71,7 +71,14 @@ class IbPageViewModel extends BaseModel {
 
     if (markdown.isNotEmpty) {
       await _offlineService.saveChapter(id, markdown);
-      isOfflineAvailable = true;
+      if (markdown.isNotEmpty) {
+        try {
+          await _offlineService.saveChapter(id, markdown);
+          isOfflineAvailable = true;
+        } catch (_) {
+          isOfflineAvailable = false;
+        }
+      }
     }
 
     // setStateFor(IB_FETCH_PAGE_DATA, ViewState.Success);

--- a/lib/viewmodels/ib/ib_page_viewmodel.dart
+++ b/lib/viewmodels/ib/ib_page_viewmodel.dart
@@ -8,12 +8,23 @@ import 'package:mobile_app/models/ib/ib_showcase.dart';
 import 'package:mobile_app/services/ib_engine_service.dart';
 import 'package:mobile_app/viewmodels/base_viewmodel.dart';
 import 'package:showcaseview/showcaseview.dart';
-
+import 'package:mobile_app/services/ib_offline_service.dart';
+import 'package:mobile_app/models/ib/ib_content.dart';
 class IbPageViewModel extends BaseModel {
   // ViewState Keys
   final String IB_FETCH_PAGE_DATA = 'ib_fetch_page_data';
   final String IB_FETCH_INTERACTION_DATA = 'ib_fetch_interaction_data';
   final String IB_FETCH_POP_QUIZ = 'ib_fetch_pop_quiz';
+
+  bool disposed = false;
+
+  @override
+  void dispose() {
+    disposed = true;
+    super.dispose();
+  }  
+  final IbOfflineService _offlineService = IbOfflineService();
+  bool isOfflineAvailable = false;
 
   // List of Global Keys to be Showcase
   late List<GlobalKey> _list;
@@ -31,17 +42,61 @@ class IbPageViewModel extends BaseModel {
   IbPageData? _pageData;
   IbPageData? get pageData => _pageData;
 
-  Future? fetchPageData({String id = 'index.md'}) async {
-    try {
-      _pageData = await _ibEngineService.getPageData(id: id);
+  // Future? fetchPageData({String id = 'index.md'}) async {
+  //   try {
+  //     _pageData = await _ibEngineService.getPageData(id: id);
 
+  //     setStateFor(IB_FETCH_PAGE_DATA, ViewState.Success);
+  //   } on Failure catch (f) {
+  //     setStateFor(IB_FETCH_PAGE_DATA, ViewState.Error);
+  //     setErrorMessageFor(IB_FETCH_PAGE_DATA, f.message);
+  //   }
+  // }
+
+  Future fetchPageData({String id = 'index.md'}) async {
+
+  setStateFor(IB_FETCH_PAGE_DATA, ViewState.Busy);
+
+  try {
+    final cachedMarkdown = await _offlineService.loadChapter(id);
+
+    _pageData = await _ibEngineService.getPageData(id: id);
+
+    String markdown = "";
+    for (var c in _pageData!.content ?? []) {
+      if (c is IbMd) {
+        markdown += c.content;
+      }
+    }
+
+    if (markdown.isNotEmpty) {
+      await _offlineService.saveChapter(id, markdown);
+      isOfflineAvailable = true;
+    }
+
+    setStateFor(IB_FETCH_PAGE_DATA, ViewState.Success);
+
+  } on Failure catch (_) {
+
+    final cachedMarkdown = await _offlineService.loadChapter(id);
+
+    if (cachedMarkdown != null) {
+      _pageData = IbPageData(
+        id: id,
+        pageUrl: "",
+        title: "Offline Chapter",
+        content: [IbMd(content: cachedMarkdown)],
+      );
+
+      isOfflineAvailable = true;
       setStateFor(IB_FETCH_PAGE_DATA, ViewState.Success);
-    } on Failure catch (f) {
+    } else {
       setStateFor(IB_FETCH_PAGE_DATA, ViewState.Error);
-      setErrorMessageFor(IB_FETCH_PAGE_DATA, f.message);
     }
   }
 
+  
+}
   Future fetchHtmlInteraction(String id) async {
     try {
       var result = await _ibEngineService.getHtmlInteraction(id);
@@ -62,14 +117,30 @@ class IbPageViewModel extends BaseModel {
     if (!state.prevButton) _list.add(_prevPage);
     if (!state.drawerButton) _list.add(keysMap['drawer']);
     if (!state.tocButton) _list.add(keysMap['toc']);
+    if (_list.isEmpty) return;
+    
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Future.delayed(const Duration(milliseconds: 500), () {
+        if (!showCaseWidgetState.mounted) return;
+          final validKeys = _list.where((key) {
+            final ctx = key.currentContext;
+            if (ctx == null) return false;
 
-    if (_list.isNotEmpty) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        Future.delayed(const Duration(milliseconds: 800), () {
-          showCaseWidgetState.startShowCase(_list);
-        });
+            final renderObject = ctx.findRenderObject();
+            if (renderObject == null) return false;
+            if (!renderObject.attached) return false;
+
+            return true;
+          }).toList();
+          if (validKeys.isEmpty) return;
+          try {
+            showCaseWidgetState.startShowCase(validKeys);
+          }
+          catch (e) {
+            debugPrint("Showcase skipped: $e");
+        }
       });
-    }
+    });
   }
 
   List<IbPopQuizQuestion>? fetchPopQuiz(String rawContent) {

--- a/lib/viewmodels/ib/ib_page_viewmodel.dart
+++ b/lib/viewmodels/ib/ib_page_viewmodel.dart
@@ -97,6 +97,7 @@ class IbPageViewModel extends BaseModel {
         content: [IbMd(content: cachedMarkdown)],
         tableOfContents: _pageData?.tableOfContents,
         chapterOfContents: _pageData?.chapterOfContents,
+        
       );
 
       isOfflineAvailable = true;

--- a/lib/viewmodels/ib/ib_page_viewmodel.dart
+++ b/lib/viewmodels/ib/ib_page_viewmodel.dart
@@ -55,10 +55,10 @@ class IbPageViewModel extends BaseModel {
 
   Future fetchPageData({String id = 'index.md'}) async {
 
-  setStateFor(IB_FETCH_PAGE_DATA, ViewState.Busy);
-
+  if (!disposed) {
+    setStateFor(IB_FETCH_PAGE_DATA, ViewState.Busy);
+  }
   try {
-    final cachedMarkdown = await _offlineService.loadChapter(id);
 
     _pageData = await _ibEngineService.getPageData(id: id);
 
@@ -74,7 +74,10 @@ class IbPageViewModel extends BaseModel {
       isOfflineAvailable = true;
     }
 
-    setStateFor(IB_FETCH_PAGE_DATA, ViewState.Success);
+    // setStateFor(IB_FETCH_PAGE_DATA, ViewState.Success);
+    if (!disposed) {
+      setStateFor(IB_FETCH_PAGE_DATA, ViewState.Success);
+    }
 
   } on Failure catch (_) {
 
@@ -89,9 +92,15 @@ class IbPageViewModel extends BaseModel {
       );
 
       isOfflineAvailable = true;
-      setStateFor(IB_FETCH_PAGE_DATA, ViewState.Success);
+      // setStateFor(IB_FETCH_PAGE_DATA, ViewState.Success);
+      if (!disposed) {
+        setStateFor(IB_FETCH_PAGE_DATA, ViewState.Success);
+      }
     } else {
-      setStateFor(IB_FETCH_PAGE_DATA, ViewState.Error);
+      // setStateFor(IB_FETCH_PAGE_DATA, ViewState.Error);
+      if (!disposed) {
+        setStateFor(IB_FETCH_PAGE_DATA, ViewState.Error);
+      }
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   datetime_picker_formfield: ^2.0.0
   flutter:
     sdk: flutter
-  
+  connectivity_plus: ^7.0.0
   flutter_inappwebview: ^6.1.5
   flutter_html: ^3.0.0-alpha.6
   flutter_keyboard_visibility: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   datetime_picker_formfield: ^2.0.0
   flutter:
     sdk: flutter
-  connectivity_plus: ^7.0.0
+  connectivity_plus: ^6.0.3
   flutter_inappwebview: ^6.1.5
   flutter_html: ^3.0.0-alpha.6
   flutter_keyboard_visibility: ^6.0.0


### PR DESCRIPTION
Fixes #528 

Describe the changes you have made in this PR :
This PR adds offline reading support for Interactive Book chapters in the mobile app

Features implemented:

* Chapters are **cached locally after the first successful load**
* If the network request fails, the app **loads the cached chapter**
* Added an **"Offline Available" badge** to indicate cached chapters
* Implemented lifecycle safety checks to avoid render and scroll errors

Implementation details:
* Added an `IbOfflineService` to store chapter markdown locally
* Updated `IbPageViewModel` to:

  * save chapter content after loading
  * load cached content if API request fails
* Updated `IbPageView` to display an **Offline Available badge** when cached content exists

Benefits:
* Allows users to **read previously opened chapters without internet**
* Improves usability for students in **low-connectivity environments**
* Reduces repeated network requests for the same chapters

Screenshots of the changes (If any) -


Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline chapter caching with an in-app "Offline Available" banner.
  * Background network connectivity check to adapt online/offline behavior.

* **Improvements**
  * Streamlined password-reset flow with inline server error display and clearer success feedback.
  * Improved offline fallback: cached content used when live fetch fails.

* **Localization**
  * Added "Reset instructions sent successfully" and Arabic/Hindi translations.

* **Chores**
  * Updated ignore settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->