### PR TITLE
fix(auth): clear token from SharedPreferences on logout

### DIFF
--- a/lib/services/local_storage_service.dart
+++ b/lib/services/local_storage_service.dart
@@ -31,6 +31,10 @@ class LocalStorageService {
   void _saveToDisk<T>(String key, T content) {
     debugPrint('LocalStorageService:_saveToDisk. key: $key value: $content');
 
+    if (content == null) {
+      _preferences!.remove(key);
+      return;
+    }
     if (content is String) {
       _preferences!.setString(key, content);
     }


### PR DESCRIPTION
Fixes #536

Describe the changes you have made in this PR -
- Added a `null` check in `lib/services/local_storage_service.dart` at the beginning of `_saveToDisk()`.
- Previously, null values were ignored because they failed the `content is String` check, resulting in tokens never actually being removed from `SharedPreferences` when a user logged out. 
- Now, passing `null` correctly triggers `_preferences!.remove(key)` directly.

Screenshots of the changes (If any) -
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local storage handling to properly clear stored data when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->