### PR TITLE
fix(auth): prevent partial authentication state on fetch user failure

### DIFF
--- a/lib/viewmodels/authentication/login_viewmodel.dart
+++ b/lib/viewmodels/authentication/login_viewmodel.dart
@@ -20,11 +20,11 @@ class LoginViewModel extends BaseModel {
       // store token in local storage..
       _storage.token = token;
 
-      // update is_logged_in status..
-      _storage.isLoggedIn = true;
-
       // save current user to local storage..
       _storage.currentUser = await _userApi.fetchCurrentUser();
+
+      // update is_logged_in status..
+      _storage.isLoggedIn = true;
 
       setStateFor(LOGIN, ViewState.Success);
     } on Failure catch (f) {

--- a/lib/viewmodels/authentication/login_viewmodel.dart
+++ b/lib/viewmodels/authentication/login_viewmodel.dart
@@ -28,6 +28,11 @@ class LoginViewModel extends BaseModel {
 
       setStateFor(LOGIN, ViewState.Success);
     } on Failure catch (f) {
+      // rollback partial auth state
+      _storage.token = null;
+      _storage.currentUser = null;
+      _storage.isLoggedIn = false;
+
       setStateFor(LOGIN, ViewState.Error);
       setErrorMessageFor(LOGIN, f.message);
     }

--- a/lib/viewmodels/authentication/signup_viewmodel.dart
+++ b/lib/viewmodels/authentication/signup_viewmodel.dart
@@ -28,6 +28,11 @@ class SignupViewModel extends BaseModel {
 
       setStateFor(SIGNUP, ViewState.Success);
     } on Failure catch (f) {
+      // rollback partial auth state
+      _storage.token = null;
+      _storage.currentUser = null;
+      _storage.isLoggedIn = false;
+
       setStateFor(SIGNUP, ViewState.Error);
       setErrorMessageFor(SIGNUP, f.message);
     }

--- a/lib/viewmodels/authentication/signup_viewmodel.dart
+++ b/lib/viewmodels/authentication/signup_viewmodel.dart
@@ -20,11 +20,11 @@ class SignupViewModel extends BaseModel {
       // store token in local storage..
       _storage.token = token;
 
-      // update is_logged_in status..
-      _storage.isLoggedIn = true;
-
       // save current user to local storage..
       _storage.currentUser = await _userApi.fetchCurrentUser();
+
+      // update is_logged_in status..
+      _storage.isLoggedIn = true;
 
       setStateFor(SIGNUP, ViewState.Success);
     } on Failure catch (f) {

--- a/test/viewmodel_tests/authentication/login_viewmodel_test.dart
+++ b/test/viewmodel_tests/authentication/login_viewmodel_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile_app/enums/view_state.dart';
 import 'package:mobile_app/models/failure_model.dart';
+import 'package:mobile_app/locator.dart';
+import 'package:mobile_app/services/local_storage_service.dart';
 import 'package:mobile_app/viewmodels/authentication/login_viewmodel.dart';
 import 'package:mockito/mockito.dart';
 
@@ -41,6 +43,11 @@ void main() {
         // should call login with expected variables
         verify(_mockUsersApi.login('test@test.com', 'password'));
         expect(_model.stateFor(_model.LOGIN), ViewState.Error);
+
+        var _mockStorage = locator<LocalStorageService>();
+        verify(_mockStorage.token = null);
+        verify(_mockStorage.currentUser = null);
+        verify(_mockStorage.isLoggedIn = false);
       });
     });
   });

--- a/test/viewmodel_tests/authentication/signup_viewmodel_test.dart
+++ b/test/viewmodel_tests/authentication/signup_viewmodel_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile_app/enums/view_state.dart';
 import 'package:mobile_app/models/failure_model.dart';
+import 'package:mobile_app/locator.dart';
+import 'package:mobile_app/services/local_storage_service.dart';
 import 'package:mobile_app/viewmodels/authentication/signup_viewmodel.dart';
 import 'package:mockito/mockito.dart';
 
@@ -41,6 +43,11 @@ void main() {
         // should call login with expected variables
         verify(_mockUsersApi.signup('test', 'test@test.com', 'password'));
         expect(_model.stateFor(_model.SIGNUP), ViewState.Error);
+
+        var _mockStorage = locator<LocalStorageService>();
+        verify(_mockStorage.token = null);
+        verify(_mockStorage.currentUser = null);
+        verify(_mockStorage.isLoggedIn = false);
       });
     });
   });


### PR DESCRIPTION
Fixes #537

Describe the changes you have made in this PR -
- Fixed a fatal UI crash spanning multiple drawer/profile views caused by a partial authentication state logic bug.
- Re-ordered the login sequence in `LoginViewModel` and `SignupViewModel`. Previously, `_storage.isLoggedIn = true` was being assigned before the network call to fetch user profile data completed. 
- Now, the codebase verifies that `fetchCurrentUser()` has successfully fetched data and mapped the model before allowing the application state to reflect a logged-in status.

Screenshots of the changes (If any) -
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reordered authentication operations in login and signup flows to set logged-in status after user data is successfully fetched and saved, improving initialization sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->