### PR TITLE
Fix: FlutterError on Snackbar Overlay

### DIFF
--- a/lib/ui/components/cv_drawer.dart
+++ b/lib/ui/components/cv_drawer.dart
@@ -220,7 +220,37 @@ class CVDrawer extends StatelessWidget {
                         ),
                       ),
                       InkWell(
-                        onTap: _model.onLogoutPressed,
+                        onTap: () async {
+                          final messenger = ScaffoldMessenger.of(context);
+                          final logoutSuccess = AppLocalizations.of(context)!.cv_logout_success;
+                          final logoutAck = AppLocalizations.of(context)!.cv_logout_success_acknowledgement;
+                          final confirmed = await _model.onLogoutPressed();
+                          if (confirmed) {
+                            messenger.showSnackBar(
+                              SnackBar(
+                                content: Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      logoutSuccess,
+                                      style: const TextStyle(
+                                        color: Colors.white,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                    Text(logoutAck, style: const TextStyle(color: Colors.white)),
+                                  ],
+                                ),
+                                backgroundColor: Colors.black.withValues(alpha: 0.85),
+                                behavior: SnackBarBehavior.floating,
+                                margin: const EdgeInsets.all(12),
+                                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                                duration: const Duration(seconds: 2),
+                              ),
+                            );
+                          }
+                        },
                         child: CVDrawerTile(
                           title: AppLocalizations.of(context)!.cv_logout,
                           iconData: FontAwesome.logout,

--- a/lib/ui/views/authentication/login_view.dart
+++ b/lib/ui/views/authentication/login_view.dart
@@ -128,24 +128,36 @@ class _LoginViewState extends State<LoginView> {
   }
 
   Future<void> _validateAndSubmit() async {
-    if (Validators.validateAndSaveForm(_formKey) &&
-        !_model.isBusy(_model.LOGIN)) {
-      FocusScope.of(context).requestFocus(FocusNode());
-      await _model.login(_email, _password);
-      if (_model.isSuccess(_model.LOGIN)) {
-        SnackBarUtils.showDark(
-          AppLocalizations.of(context)!.login_success_title,
-          AppLocalizations.of(context)!.login_success_message,
-        );
-        await Future.delayed(const Duration(seconds: 1));
-        await Get.offAllNamed(CVLandingView.id);
-      } else if (_model.isError(_model.LOGIN)) {
-        SnackBarUtils.showDark(
-          AppLocalizations.of(context)!.login_error,
-          _model.errorMessageFor(_model.LOGIN),
-        );
-        _formKey.currentState?.reset();
-      }
+    if (!Validators.validateAndSaveForm(_formKey) ||
+        _model.isBusy(_model.LOGIN)) {
+      return;
+    }
+
+    // Dismiss keyboard
+    FocusScope.of(context).unfocus();
+
+    await _model.login(_email, _password);
+
+    // Capture strings BEFORE any async navigation (important)
+    final successTitle = AppLocalizations.of(context)!.login_success_title;
+    final successMessage = AppLocalizations.of(context)!.login_success_message;
+
+    final errorTitle = AppLocalizations.of(context)!.login_error;
+    final errorMessage = _model.errorMessageFor(_model.LOGIN);
+
+    if (_model.isSuccess(_model.LOGIN)) {
+      // Navigate first (ensures overlay exists)
+      await Get.offAllNamed(CVLandingView.id);
+
+      // Small delay ensures new screen is mounted
+      Future.delayed(const Duration(milliseconds: 100), () {
+        SnackBarUtils.showDark(successTitle, successMessage);
+      });
+    } else if (_model.isError(_model.LOGIN)) {
+      // Snackbar is safe here (no navigation happening)
+      SnackBarUtils.showDark(errorTitle, errorMessage);
+
+      _formKey.currentState?.reset();
     }
   }
 

--- a/lib/utils/snackbar_utils.dart
+++ b/lib/utils/snackbar_utils.dart
@@ -3,16 +3,55 @@ import 'package:get/get.dart';
 
 class SnackBarUtils {
   static void showLight(String title, String message) {
-    Get.snackbar(title, message, snackPosition: SnackPosition.BOTTOM);
+    _show(
+      title: title,
+      message: message,
+      backgroundColor: Colors.white,
+      textColor: Colors.black,
+    );
   }
 
   static void showDark(String title, String message) {
-    Get.snackbar(
-      title,
-      message,
-      snackPosition: SnackPosition.BOTTOM,
-      backgroundColor: Colors.black.withValues(alpha: 0.8),
-      colorText: Colors.white,
+    _show(
+      title: title,
+      message: message,
+      backgroundColor: Colors.black.withValues(alpha: 0.85),
+      textColor: Colors.white,
     );
+  }
+
+  static void _show({
+    required String title,
+    required String message,
+    required Color backgroundColor,
+    required Color textColor,
+  }) {
+    if (Get.context == null) return;
+
+    if (Get.isSnackbarOpen) {
+      Get.closeCurrentSnackbar();
+    }
+
+    Future.microtask(() {
+      Get.rawSnackbar(
+        snackPosition: SnackPosition.BOTTOM,
+        backgroundColor: backgroundColor,
+        margin: const EdgeInsets.all(12),
+        borderRadius: 8,
+        duration: const Duration(seconds: 2),
+        isDismissible: true,
+        titleText: Text(
+          title,
+          style: TextStyle(
+            color: textColor,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        messageText: Text(
+          message,
+          style: TextStyle(color: textColor),
+        ),
+      );
+    });
   }
 }

--- a/lib/utils/snackbar_utils.dart
+++ b/lib/utils/snackbar_utils.dart
@@ -20,6 +20,36 @@ class SnackBarUtils {
     );
   }
 
+  static void showDarkWithContext(
+    BuildContext context,
+    String title,
+    String message,
+  ) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            Text(message, style: const TextStyle(color: Colors.white)),
+          ],
+        ),
+        backgroundColor: Colors.black.withValues(alpha: 0.85),
+        behavior: SnackBarBehavior.floating,
+        margin: const EdgeInsets.all(12),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+
   static void _show({
     required String title,
     required String message,

--- a/lib/viewmodels/cv_landing_viewmodel.dart
+++ b/lib/viewmodels/cv_landing_viewmodel.dart
@@ -80,23 +80,22 @@ class CVLandingViewModel extends BaseModel {
     }
   }
 
-  Future<void> onLogoutPressed() async {
+  Future<bool> onLogoutPressed() async {
     Get.back();
 
-    var _dialogResponse = await _dialogService.showConfirmationDialog(
+    var response = await _dialogService.showConfirmationDialog(
       title: AppLocalizations.of(Get.context!)!.cv_logout,
       description: AppLocalizations.of(Get.context!)!.cv_logout_confirmation,
       confirmationTitle:
           AppLocalizations.of(Get.context!)!.cv_logout_confirmation_button,
     );
 
-    if (_dialogResponse?.confirmed ?? false) {
+    if (response?.confirmed ?? false) {
       onLogout();
       selectedIndex = 0;
-      SnackBarUtils.showDark(
-        AppLocalizations.of(Get.context!)!.cv_logout_success,
-        AppLocalizations.of(Get.context!)!.cv_logout_success_acknowledgement,
-      );
+      return true; 
     }
+
+    return false;
   }
 }


### PR DESCRIPTION
Fixes #

This fixes the FlutterError on Snackbar Overlay issue #545 

Login issue: the snackbar was trying to show before the app's overlay (the layer that displays floating UI like snackbars) was fully ready. Fixed by wrapping the call in a `Future.microtask` so it waits for the overlay to be mounted.

Logout issue: the snackbar was trying to show after the overlay was already destroyed. When logout fires, it clears the user session and triggers a navigation change that tears down the overlay — and GetX's snackbar queue runs too late, finding nothing to attach to. Fixed by capturing the `ScaffoldMessengerState` before logout starts, since it lives higher in the widget tree and survives navigation changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Logout operations now provide immediate user feedback with a localized confirmation message.

* **Bug Fixes**
  * Optimized login form validation flow with improved error handling and messaging.
  * Enhanced notification styling and context-aware display for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->