### PR TITLE
Added contributors image caching mechanism

### DIFF
--- a/lib/ui/views/about/components/contributor_avatar.dart
+++ b/lib/ui/views/about/components/contributor_avatar.dart
@@ -1,8 +1,8 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile_app/cv_theme.dart';
 import 'package:mobile_app/models/cv_contributors.dart';
 import 'package:mobile_app/utils/url_launcher.dart';
-import 'package:transparent_image/transparent_image.dart';
 
 class ContributorAvatar extends StatelessWidget {
   const ContributorAvatar({required this.contributor, super.key});
@@ -24,9 +24,13 @@ class ContributorAvatar extends StatelessWidget {
           ),
           child: ClipRRect(
             borderRadius: BorderRadius.circular(24),
-            child: FadeInImage.memoryNetwork(
-              placeholder: kTransparentImage,
-              image: contributor.avatarUrl,
+            child: CachedNetworkImage(
+              imageUrl: contributor.avatarUrl,
+              placeholder: (context, url) => Container(
+                color: Colors.grey[300],
+              ),
+              errorWidget: (context, url, error) => const Icon(Icons.error),
+              fit: BoxFit.cover,
             ),
           ),
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   markdown: any
   webview_flutter: 4.13.1
   flutter_quill: ^11.4.2
+  cached_network_image: ^3.4.1
 dev_dependencies:
   mockito: ^5.4.4
   build_runner: ^2.4.13


### PR DESCRIPTION
This PR adds contributors image caching mechanism in the about page using cached_network_image.

Presently in the about page, Images were downloaded fresh on every page visit and Contributors' avatars had to be fetched from GitHub's servers each time. Also Images wouldn't display if the network was unavailable.

This mechanism solves these issues
