### PR TITLE
fix: resolve memory leak in AssignmentDetailsView

### DIFF
--- a/lib/ui/views/groups/assignment_details_view.dart
+++ b/lib/ui/views/groups/assignment_details_view.dart
@@ -43,6 +43,8 @@ class _AssignmentDetailsViewState extends State<AssignmentDetailsView> {
   @override
   void dispose() {
     _gradeFocusNode.dispose();
+    _gradesController.dispose();
+    _remarksController.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
Fixes  #554

changes made in this PR -

 ### What we changed:
- Added `_gradesController.dispose()` and `_remarksController.dispose()` inside the [dispose()](cci:1://file:///Users/rajeevtiwari/Desktop/openSource/mobile-app/lib/ui/views/projects/edit_project_view.dart:42:2-49:3) method in [lib/ui/views/groups/assignment_details_view.dart](cci:7://file:///Users/rajeevtiwari/Desktop/openSource/mobile-app/lib/ui/views/groups/assignment_details_view.dart:0:0-0:0).

### Why it was changed:
- These `TextEditingController` instances were being initialized but never disposed of when the mentor navigated away from the Assignment Details page.
- This missing cleanup led to the controllers and their listeners remaining active in the background, causing a memory leak over time.
- Adding the [dispose()](cci:1://file:///Users/rajeevtiwari/Desktop/openSource/mobile-app/lib/ui/views/projects/edit_project_view.dart:42:2-49:3) calls safely frees up memory resources when the widget unmounts.


## Summary by CodeRabbit

## Bug Fixes

* **Improved resource management** - Fixed memory leak in the assignment details view by properly releasing unused resources during cleanup, enhancing app stability and performance.
