### PR TITLE
fix: replace GestureDetector with InkWell in ProjectCard for ripple f…

### DIFF
--- a/lib/ui/views/projects/components/project_card.dart
+++ b/lib/ui/views/projects/components/project_card.dart
@@ -112,14 +112,14 @@ class _ProjectCardState extends State<ProjectCard> {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsetsDirectional.all(8.0),
-      child: Card(
-        elevation: 5,
-        shadowColor: CVTheme.primaryColorLight,
-        clipBehavior: Clip.antiAlias,
-        child: InkWell(
-          onTap: widget.onPressed,
+    return InkWell(
+      onTap: widget.onPressed,
+      child: Padding(
+        padding: const EdgeInsetsDirectional.all(8.0),
+        child: Card(
+          elevation: 5,
+          shadowColor: CVTheme.primaryColorLight,
+          clipBehavior: Clip.antiAlias,
           child: Column(
             mainAxisAlignment: MainAxisAlignment.start,
             children: <Widget>[_buildHeader(), _buildPreview()],

--- a/lib/ui/views/projects/components/project_card.dart
+++ b/lib/ui/views/projects/components/project_card.dart
@@ -112,13 +112,14 @@ class _ProjectCardState extends State<ProjectCard> {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: widget.onPressed,
-      child: Padding(
-        padding: const EdgeInsetsDirectional.all(8.0),
-        child: Card(
-          elevation: 5,
-          shadowColor: CVTheme.primaryColorLight,
+    return Padding(
+      padding: const EdgeInsetsDirectional.all(8.0),
+      child: Card(
+        elevation: 5,
+        shadowColor: CVTheme.primaryColorLight,
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: widget.onPressed,
           child: Column(
             mainAxisAlignment: MainAxisAlignment.start,
             children: <Widget>[_buildHeader(), _buildPreview()],


### PR DESCRIPTION
**Fixes #559**

### Describe the changes you have made in this PR:
- Replaced `GestureDetector` with `InkWell` inside the [Card](cci:2://file:///Users/rajeevtiwari/Desktop/openSource/mobile-app/lib/ui/views/projects/components/project_card.dart:6:0-20:1) widget in [lib/ui/views/projects/components/project_card.dart](cci:7://file:///Users/rajeevtiwari/Desktop/openSource/mobile-app/lib/ui/views/projects/components/project_card.dart:0:0-0:0).
- Added `clipBehavior: Clip.antiAlias` to the [Card](cci:2://file:///Users/rajeevtiwari/Desktop/openSource/mobile-app/lib/ui/views/projects/components/project_card.dart:6:0-20:1) to ensure the Material ripple effect stays neatly bounded within the card's rounded corners.

### Why these changes were necessary:
The [ProjectCard](cci:2://file:///Users/rajeevtiwari/Desktop/openSource/mobile-app/lib/ui/views/projects/components/project_card.dart:6:0-20:1) component was using `GestureDetector` to handle taps, which captures touch events but provides **no visual feedback** to the user. This makes the card feel unresponsive and "dead" when tapped. By switching to `InkWell` (a proper Material Design widget), users now see a smooth ripple animation every time they tap a project card, making the app feel significantly more interactive and polished.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Project cards now provide material-style ink ripple feedback with improved tap responsiveness. Visual interaction boundaries are better aligned with card edges so ripples and highlights are clipped neatly, while existing spacing and layout are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->