### PR TITLE
docs: add Chrome CORS workaround for local web development

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ Make sure you have a connected Android/iOS device/simulator and run the followin
 
 `flutter run`
 
+#### Running on Chrome (Web)
+
+To run the app on Chrome, use:
+
+`flutter run -d chrome`
+
+> **Note:** When running on Chrome locally, all API calls to `circuitverse.org` will be blocked by the browser's **CORS policy**. This causes Login, Register, and all data loading to fail. To bypass this during local development, launch Chrome with the `--disable-web-security` flag:
+
+```bash
+flutter run -d chrome --web-browser-flag "--disable-web-security"
+```
+
+> ⚠️ Only use `--disable-web-security` for **local development**. Never use it in production.
+
 ### Android OAuth Config
 
 This project uses Flutter 3.32.2 and hence the support for compile-time variables. To use compile-time variables pass them in `--dart-defines` as `flutter run --dart-define=VAR_NAME=VAR_VALUE`. Supported `dart-defines` include :


### PR DESCRIPTION
**Fixes #561**

### Describe the changes you have made in this PR:
- Added a new **"Running on Chrome (Web)"** subsection to [README.md](cci:7://file:///Users/rajeevtiwari/Desktop/openSource/mobile-app/README.md:0:0-0:0).
- Documented the CORS policy error that blocks all API requests (Login, Register, data loading) when running `flutter run -d chrome` from `localhost`.
- Added the `--disable-web-security` workaround flag so contributors can test the app locally on Chrome without CORS errors.

### Why these changes were necessary:
Contributors running the app on Chrome had no documentation explaining why all API calls fail with CORS errors, making local web development very confusing. This update saves future contributors from spending time debugging a known browser limitation.
###before 
<img width="1470" height="956" alt="Screenshot 2026-03-25 at 1 26 06 PM" src="https://github.com/user-attachments/assets/b61f33dc-153f-462b-87b9-c89c7b26ce64" />

###after fixing
<img width="1470" height="956" alt="Screenshot 2026-03-25 at 1 34 44 PM" src="https://github.com/user-attachments/assets/85951cb2-6417-41a6-ad52-5ddb65d1b702" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for running the app on Chrome (Web), including information about CORS restrictions and available workarounds for local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->