### PR TITLE
Fix/image cropper web settings

### DIFF
--- a/lib/services/API/users_api.dart
+++ b/lib/services/API/users_api.dart
@@ -1,6 +1,5 @@
-import 'dart:io';
-
 import 'package:http/http.dart' as http;
+import 'package:image_picker/image_picker.dart';
 import 'package:mobile_app/config/environment_config.dart';
 import 'package:mobile_app/constants.dart';
 import 'package:mobile_app/locator.dart';
@@ -34,7 +33,7 @@ abstract class UsersApi {
     String? educationalInstitute,
     String? country,
     bool subscribed,
-    File? image,
+    XFile? image,
     bool removePicture,
   );
 
@@ -163,7 +162,7 @@ class HttpUsersApi implements UsersApi {
     String? educationalInstitute,
     String? country,
     bool isSubscribed,
-    File? image,
+    XFile? image,
     bool removePicture,
   ) async {
     var endpoint = '/users/${_storage.currentUser!.data.id}';
@@ -181,8 +180,13 @@ class HttpUsersApi implements UsersApi {
 
     var files = <http.MultipartFile>[];
     if (image != null) {
+      var _bytes = await image.readAsBytes();
       files.add(
-        await http.MultipartFile.fromPath('profile_picture', image.path),
+        http.MultipartFile.fromBytes(
+          'profile_picture',
+          _bytes,
+          filename: image.name,
+        ),
       );
     }
 

--- a/lib/ui/views/profile/edit_profile_view.dart
+++ b/lib/ui/views/profile/edit_profile_view.dart
@@ -119,7 +119,7 @@ class _EditProfileViewState extends State<EditProfileView> {
                   children: List.generate(2, (index) {
                     return GestureDetector(
                       onTap: () {
-                        _model.pickProfileImage(index);
+                        _model.pickProfileImage(context, index);
                         Get.back();
                       },
                       child: Padding(

--- a/lib/ui/views/profile/edit_profile_view.dart
+++ b/lib/ui/views/profile/edit_profile_view.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/cv_theme.dart';
@@ -157,12 +160,14 @@ class _EditProfileViewState extends State<EditProfileView> {
                 image: DecorationImage(
                   image:
                       _model.imageUpdated
-                          ? FileImage(_model.updatedImage!)
+                          ? (kIsWeb
+                              ? NetworkImage(_model.updatedImage!.path)
+                              : FileImage(File(_model.updatedImage!.path)))
                           : imageURL.toLowerCase().contains('default') ||
                               _model.removeImage
                           ? const AssetImage(
                             'assets/images/profile/default_icon.jpg',
-                          )
+                          ) as ImageProvider
                           : NetworkImage(imageURL) as ImageProvider,
                 ),
               ),

--- a/lib/viewmodels/profile/edit_profile_viewmodel.dart
+++ b/lib/viewmodels/profile/edit_profile_viewmodel.dart
@@ -1,5 +1,5 @@
 import 'dart:io';
-
+import 'package:flutter/material.dart';
 import 'package:image_cropper/image_cropper.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:mobile_app/enums/view_state.dart';
@@ -31,7 +31,7 @@ class EditProfileViewModel extends BaseModel {
     notifyListeners();
   }
 
-  void pickProfileImage(int index) async {
+  void pickProfileImage(BuildContext context, int index) async {
     removeImage = false;
     final _image = await _picker.pickImage(
       source: index == 0 ? ImageSource.camera : ImageSource.gallery,
@@ -45,6 +45,11 @@ class EditProfileViewModel extends BaseModel {
       compressQuality: 100,
       maxHeight: 1000,
       maxWidth: 1000,
+      uiSettings: [
+        WebUiSettings(
+          context: context,
+        ),
+      ],
     );
 
     if (_croppedImage == null) return;

--- a/lib/viewmodels/profile/edit_profile_viewmodel.dart
+++ b/lib/viewmodels/profile/edit_profile_viewmodel.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:image_cropper/image_cropper.dart';
 import 'package:image_picker/image_picker.dart';
@@ -20,7 +19,7 @@ class EditProfileViewModel extends BaseModel {
   final ImageCropper _cropper = ImageCropper();
 
   bool imageUpdated = false, removeImage = false;
-  File? updatedImage;
+  CroppedFile? updatedImage;
 
   User? _updatedUser;
 
@@ -55,7 +54,7 @@ class EditProfileViewModel extends BaseModel {
     if (_croppedImage == null) return;
 
     imageUpdated = true;
-    updatedImage = File(_croppedImage.path);
+    updatedImage = _croppedImage;
     notifyListeners();
   }
 
@@ -79,7 +78,7 @@ class EditProfileViewModel extends BaseModel {
         educationalInstitute,
         country,
         subscribed,
-        updatedImage,
+        updatedImage != null ? XFile(updatedImage!.path) : null,
         removeImage,
       );
       _storage.currentUser = _updatedUser;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -873,26 +873,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -946,10 +946,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: "direct overridden"
     description:
@@ -959,7 +959,7 @@ packages:
     source: hosted
     version: "1.0.6"
   mockito:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: mockito
       sha256: "6841eed20a7befac0ce07df8116c8b8233ed1f4486a7647c7fc5a02ae6163917"
@@ -1306,10 +1306,10 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64"
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "2.5.3"
   shared_preferences_android:
     dependency: transitive
     description:
@@ -1471,10 +1471,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.4"
   theme_provider:
     dependency: "direct main"
     description:
@@ -1623,10 +1623,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
@@ -1741,4 +1741,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.27.0"
+  flutter: ">=3.32.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   provider: ^6.1.5
   scroll_to_index: ^3.0.1
   share_plus: ^11.1.0
-  shared_preferences: ^2.5.4
+  shared_preferences: ^2.5.3
   showcaseview: ^4.0.1
   simple_chips_input: ^1.2.2
   theme_provider: ^0.6.0


### PR DESCRIPTION
Fixes #563 
Fixes #564

### Describe the changes you have made in this PR:
- Refactored `UsersApi.updateProfile` to accept `XFile` instead of `File`.
- Implemented `MultipartFile.fromBytes` for profile image uploads to ensure cross-platform compatibility (Web/Mobile).
- Updated `EditProfileViewModel` to use `CroppedFile` (XFile compatible) for the updated image.
- Updated `EditProfileView` with a platform-aware image preview (NetworkImage for Web, FileImage for Mobile).
- Added mandatory `WebUiSettings` to the `ImageCropper` call.

### Why these changes were necessary:
The app crashed on Web whenever a user tried to pick or upload a profile photo because `dart:io` and native file paths are not supported in browsers. These changes make the profile update feature fully functional on the Web.


before fixing bug

<img width="1470" height="956" alt="Screenshot 2026-03-26 at 7 12 44 PM" src="https://github.com/user-attachments/assets/154bcc60-6445-49c9-996b-fb65fc22dfd4" />
after fixing bug ->i can edit the profile photo
<img width="1470" height="956" alt="Screenshot 2026-03-26 at 7 43 18 PM" src="https://github.com/user-attachments/assets/6f99ea61-311e-45a6-9522-84552c1a9a95" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced profile image upload functionality with improved cross-platform compatibility.
  * Refined profile image display handling to ensure consistent performance on both web and native platforms.
  * Better support for image processing and preview updates during profile editing.

* **Dependencies**
  * Updated shared_preferences package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->