### PR TITLE
fix: resolve framework assertion crash in Interactive Books caused by…

### DIFF
--- a/lib/ui/views/ib/ib_page_view.dart
+++ b/lib/ui/views/ib/ib_page_view.dart
@@ -152,6 +152,7 @@ class _IbPageViewState extends State<IbPageView> {
     };
 
     return MarkdownBody(
+      key: ValueKey(data.content),
       shrinkWrap: false,
       data: data.content,
       selectable: _selectable,

--- a/lib/ui/views/ib/ib_page_view.dart
+++ b/lib/ui/views/ib/ib_page_view.dart
@@ -152,7 +152,6 @@ class _IbPageViewState extends State<IbPageView> {
     };
 
     return MarkdownBody(
-      key: UniqueKey(),
       shrinkWrap: false,
       data: data.content,
       selectable: _selectable,


### PR DESCRIPTION
Title: fix: use ValueKey to prevent duplicate GlobalKey mismatches when switching chapters

Description:

What does this PR do?
Fixes a critical framework crash (Assertion failed: _elements.contains(element) is not true and Duplicate GlobalKey detected in widget tree) that occurs in the Interactive Books viewer when rendering or navigating between chapters.

Why was this happening?
The MarkdownBody compiler in lib/ui/views/ib/ib_page_view.dart was originally given a key: UniqueKey(). Defining a UniqueKey() directly inside a build() method is an anti-pattern that destroys and unnecessarily rebuilds the entire widget subtree from scratch on every single state change. Because Interactive Books contain deep element trees holding GlobalKey references (which are used by scroll_to_index for anchoring/scrolling to specific chapter headings), tearing down and asynchronously recreating these keys on every micro-update confused the framework's element lifecycle tracking.

Furthermore, completely removing the key caused the framework to incorrectly attempt to structure-diff significantly different chapters, leading to an overlapping AutoScrollTag causing a Duplicate GlobalKey exception.

How this fixes the issue:
Changed the key in MarkdownBody from UniqueKey() to ValueKey(data.content). The widget tree is now perfectly stable during normal interaction (stopping the continuous destruction cycle), but reliably destroys and recreates itself securely when the user switches to studying a different chapter or the textual content changes.


before
<img width="1470" height="956" alt="Screenshot 2026-04-14 at 4 00 49 PM" src="https://github.com/user-attachments/assets/e259d9ad-8e59-4635-94e5-8bf71d14f3e7" />


after

<img width="1470" height="956" alt="Screenshot 2026-04-14 at 4 21 47 PM" src="https://github.com/user-attachments/assets/704fc4bd-b2ed-4036-8982-b81977530b19" />
