### PR TITLE
Fix black screen issue

### DIFF
--- a/lib/viewmodels/cv_landing_viewmodel.dart
+++ b/lib/viewmodels/cv_landing_viewmodel.dart
@@ -74,7 +74,6 @@ class CVLandingViewModel extends BaseModel {
   }
 
   void setSelectedIndexTo(int index) {
-    Get.back();
     if (_selectedIndex != index) {
       selectedIndex = index;
     }


### PR DESCRIPTION
Due to a recent commit, the navigator was popped twice when switching to few screens like contribute and about. This caused a black screen on these screens. 
This fixes the bug.