### PR TITLE
fix: show error widget when content fails to load #84

### DIFF
--- a/lib/ui/components/cv_exception.dart
+++ b/lib/ui/components/cv_exception.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_app/cv_theme.dart';
+
+class CVException extends StatelessWidget {
+  const CVException(this.message, {super.key});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsetsDirectional.all(32),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.cloud_off_outlined, size: 64, color: Colors.grey[400]),
+          const SizedBox(height: 24),
+          Text(
+            message,
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+              color: CVTheme.textColor(context),
+              fontSize: 16,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/views/groups/assignment_details_view.dart
+++ b/lib/ui/views/groups/assignment_details_view.dart
@@ -10,6 +10,7 @@ import 'package:mobile_app/locator.dart';
 import 'package:mobile_app/models/assignments.dart';
 import 'package:mobile_app/models/grade.dart';
 import 'package:mobile_app/services/dialog_service.dart';
+import 'package:mobile_app/ui/components/cv_exception.dart';
 import 'package:mobile_app/ui/components/cv_primary_button.dart';
 import 'package:mobile_app/ui/components/cv_text_field.dart';
 import 'package:mobile_app/ui/views/base_view.dart';
@@ -523,6 +524,10 @@ class _AssignmentDetailsViewState extends State<AssignmentDetailsView> {
                           const SizedBox(height: 16),
                           _buildGrades(),
                         ],
+                      ),
+                    if (_model.isError(_model.FETCH_ASSIGNMENT_DETAILS))
+                      CVException(
+                        _model.errorMessageFor(_model.FETCH_ASSIGNMENT_DETAILS),
                       ),
                   ],
                 );

--- a/lib/ui/views/groups/group_details_view.dart
+++ b/lib/ui/views/groups/group_details_view.dart
@@ -5,6 +5,7 @@ import 'package:mobile_app/locator.dart';
 import 'package:mobile_app/models/assignments.dart';
 import 'package:mobile_app/models/groups.dart';
 import 'package:mobile_app/services/dialog_service.dart';
+import 'package:mobile_app/ui/components/cv_exception.dart';
 import 'package:mobile_app/ui/components/cv_primary_button.dart';
 import 'package:mobile_app/ui/views/base_view.dart';
 import 'package:mobile_app/ui/views/groups/add_assignment_view.dart';
@@ -574,6 +575,14 @@ class _GroupDetailsViewState extends State<GroupDetailsView> {
                       ),
                     );
                   }
+                }
+
+                if (_model.isError(_model.FETCH_GROUP_DETAILS)) {
+                  _items.add(
+                    CVException(
+                      _model.errorMessageFor(_model.FETCH_GROUP_DETAILS),
+                    ),
+                  );
                 }
 
                 return ListView(

--- a/lib/ui/views/groups/my_groups_view.dart
+++ b/lib/ui/views/groups/my_groups_view.dart
@@ -6,6 +6,7 @@ import 'package:mobile_app/locator.dart';
 import 'package:mobile_app/models/groups.dart';
 import 'package:mobile_app/services/dialog_service.dart';
 import 'package:mobile_app/ui/components/cv_add_icon_button.dart';
+import 'package:mobile_app/ui/components/cv_exception.dart';
 import 'package:mobile_app/ui/views/base_view.dart';
 import 'package:mobile_app/ui/views/groups/components/group_member_card.dart';
 import 'package:mobile_app/ui/views/groups/components/group_mentor_card.dart';
@@ -175,7 +176,16 @@ class _MyGroupsViewState extends State<MyGroupsView>
                                     height:
                                         MediaQuery.of(context).size.height *
                                         0.7,
-                                    child: _emptyState(),
+                                    child:
+                                        _model.isError(
+                                              _model.FETCH_OWNED_GROUPS,
+                                            )
+                                            ? CVException(
+                                              _model.errorMessageFor(
+                                                _model.FETCH_OWNED_GROUPS,
+                                              ),
+                                            )
+                                            : _emptyState(),
                                   ),
                                 ],
                               )
@@ -196,7 +206,16 @@ class _MyGroupsViewState extends State<MyGroupsView>
                                     height:
                                         MediaQuery.of(context).size.height *
                                         0.7,
-                                    child: _emptyState(),
+                                    child:
+                                        _model.isError(
+                                              _model.FETCH_MEMBER_GROUPS,
+                                            )
+                                            ? CVException(
+                                              _model.errorMessageFor(
+                                                _model.FETCH_MEMBER_GROUPS,
+                                              ),
+                                            )
+                                            : _emptyState(),
                                   ),
                                 ],
                               )

--- a/lib/ui/views/ib/ib_landing_view.dart
+++ b/lib/ui/views/ib/ib_landing_view.dart
@@ -5,6 +5,7 @@ import 'package:mobile_app/cv_theme.dart';
 import 'package:mobile_app/ib_theme.dart';
 import 'package:mobile_app/models/ib/ib_chapter.dart';
 import 'package:mobile_app/ui/components/cv_drawer_tile.dart';
+import 'package:mobile_app/ui/components/cv_exception.dart';
 import 'package:mobile_app/ui/components/cv_text_field.dart';
 import 'package:mobile_app/ui/views/base_view.dart';
 import 'package:mobile_app/ui/views/ib/ib_page_view.dart';
@@ -285,7 +286,9 @@ class _IbLandingViewState extends State<IbLandingView> {
                           : IbTheme.textColor(context),
                 ),
               ),
-              if (!_model.isSuccess(_model.IB_FETCH_CHAPTERS))
+              if (_model.isError(_model.IB_FETCH_CHAPTERS))
+                CVException(_model.errorMessageFor(_model.IB_FETCH_CHAPTERS))
+              else if (!_model.isSuccess(_model.IB_FETCH_CHAPTERS))
                 ListTile(
                   leading: const SizedBox(
                     width: 24,

--- a/lib/ui/views/notifications/notifications_view.dart
+++ b/lib/ui/views/notifications/notifications_view.dart
@@ -3,6 +3,7 @@ import 'package:fluttericon/font_awesome_icons.dart';
 import 'package:intl/intl.dart';
 import 'package:mobile_app/cv_theme.dart';
 import 'package:mobile_app/enums/notification_type.dart';
+import 'package:mobile_app/ui/components/cv_exception.dart';
 import 'package:mobile_app/ui/views/base_view.dart';
 import 'package:mobile_app/viewmodels/cv_landing_viewmodel.dart';
 import 'package:mobile_app/viewmodels/notifications/notifications_viewmodel.dart';
@@ -92,6 +93,10 @@ class NotificationsView extends StatelessWidget {
               ),
             ],
           );
+        }
+
+        if (model.isError(model.FETCH_NOTIFICATIONS)) {
+          return CVException(model.errorMessageFor(model.FETCH_NOTIFICATIONS));
         }
 
         final hasNoNotifications = model.notifications.isEmpty;

--- a/lib/ui/views/profile/user_favourites_view.dart
+++ b/lib/ui/views/profile/user_favourites_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/models/projects.dart';
 import 'package:mobile_app/ui/components/cv_add_icon_button.dart';
+import 'package:mobile_app/ui/components/cv_exception.dart';
 import 'package:mobile_app/ui/views/base_view.dart';
 import 'package:mobile_app/ui/views/projects/components/project_card.dart';
 import 'package:mobile_app/ui/views/projects/project_details_view.dart';
@@ -122,6 +123,12 @@ class _UserFavouritesViewState extends State<UserFavouritesView>
               );
             }
           }
+        }
+
+        if (model.isError(model.FETCH_USER_FAVOURITES)) {
+          _items.add(
+            CVException(model.errorMessageFor(model.FETCH_USER_FAVOURITES)),
+          );
         }
 
         if (model.previousUserFavouritesBatch?.links.next != null) {

--- a/lib/ui/views/profile/user_projects_view.dart
+++ b/lib/ui/views/profile/user_projects_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/models/projects.dart';
 import 'package:mobile_app/ui/components/cv_add_icon_button.dart';
+import 'package:mobile_app/ui/components/cv_exception.dart';
 import 'package:mobile_app/ui/views/base_view.dart';
 import 'package:mobile_app/ui/views/projects/components/project_card.dart';
 import 'package:mobile_app/ui/views/projects/project_details_view.dart';
@@ -120,6 +121,12 @@ class _UserProjectsViewState extends State<UserProjectsView>
               );
             }
           }
+        }
+
+        if (model.isError(model.FETCH_USER_PROJECTS)) {
+          _items.add(
+            CVException(model.errorMessageFor(model.FETCH_USER_PROJECTS)),
+          );
         }
 
         if (model.previousUserProjectsBatch?.links.next != null) {

--- a/lib/ui/views/projects/featured_projects_view.dart
+++ b/lib/ui/views/projects/featured_projects_view.dart
@@ -4,6 +4,7 @@ import 'package:get/get.dart';
 import 'package:mobile_app/cv_theme.dart';
 import 'package:mobile_app/models/projects.dart';
 import 'package:mobile_app/ui/components/cv_drawer.dart';
+import 'package:mobile_app/ui/components/cv_exception.dart';
 import 'package:mobile_app/ui/components/cv_header.dart';
 import 'package:mobile_app/ui/components/cv_text_field.dart';
 import 'package:mobile_app/ui/views/base_view.dart';
@@ -97,6 +98,18 @@ class _FeaturedProjectsViewState extends State<FeaturedProjectsView> {
             _items.add(const Center(child: CircularProgressIndicator()));
           }
 
+          _projects = _items;
+        }
+
+        if (model.isError(model.FETCH_FEATURED_PROJECTS)) {
+          _items.add(
+            CVException(model.errorMessageFor(model.FETCH_FEATURED_PROJECTS)),
+          );
+          _projects = _items;
+        }
+
+        if (model.isError(model.SEARCH_PROJECTS)) {
+          _items.add(CVException(model.errorMessageFor(model.SEARCH_PROJECTS)));
           _projects = _items;
         }
 

--- a/lib/ui/views/projects/project_details_view.dart
+++ b/lib/ui/views/projects/project_details_view.dart
@@ -8,6 +8,7 @@ import 'package:mobile_app/locator.dart';
 import 'package:mobile_app/models/collaborators.dart';
 import 'package:mobile_app/models/projects.dart';
 import 'package:mobile_app/services/dialog_service.dart';
+import 'package:mobile_app/ui/components/cv_exception.dart';
 import 'package:mobile_app/ui/components/cv_flat_button.dart';
 import 'package:mobile_app/ui/views/base_view.dart';
 import 'package:mobile_app/ui/views/profile/profile_view.dart';
@@ -767,6 +768,13 @@ class _ProjectDetailsViewState extends State<ProjectDetailsView> {
                     for (var collaborator in _model.collaborators) {
                       _items.add(_buildCollaborator(collaborator));
                     }
+                  }
+                  if (_model.isError(_model.FETCH_PROJECT_DETAILS)) {
+                    _items.add(
+                      CVException(
+                        _model.errorMessageFor(_model.FETCH_PROJECT_DETAILS),
+                      ),
+                    );
                   }
                   return ListView(
                     shrinkWrap: true,

--- a/test/ui_tests/components/cv_exception_test.dart
+++ b/test/ui_tests/components/cv_exception_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_app/ui/components/cv_exception.dart';
+
+void main() {
+  testWidgets('shows the failed-to-load message', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: CVException('Error During Communication')),
+      ),
+    );
+
+    expect(find.byType(CVException), findsOneWidget);
+    expect(find.text('Error During Communication'), findsOneWidget);
+    expect(find.byIcon(Icons.cloud_off_outlined), findsOneWidget);
+  });
+}

--- a/test/ui_tests/projects/featured_projects_view_test.dart
+++ b/test/ui_tests/projects/featured_projects_view_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/locator.dart';
 import 'package:mobile_app/models/projects.dart';
+import 'package:mobile_app/ui/components/cv_exception.dart';
 import 'package:mobile_app/ui/components/cv_header.dart';
 import 'package:mobile_app/ui/views/projects/components/featured_project_card.dart';
 import 'package:mobile_app/ui/views/projects/featured_projects_view.dart';
@@ -116,6 +117,41 @@ void main() {
         verify(mockObserver.didPush(any, any));
         expect(find.byType(ProjectDetailsView), findsOneWidget);
       });
+    });
+
+    testWidgets('shows error widget when featured projects fail to load', (
+      WidgetTester tester,
+    ) async {
+      var model = MockFeaturedProjectsViewModel();
+      locator.registerSingleton<FeaturedProjectsViewModel>(model);
+
+      when(
+        model.FETCH_FEATURED_PROJECTS,
+      ).thenAnswer((_) => 'fetch_featured_projects');
+      when(model.SEARCH_PROJECTS).thenAnswer((_) => 'search_projects');
+      when(model.isBusy(any)).thenAnswer((_) => false);
+      when(model.isSuccess(any)).thenAnswer((_) => false);
+      when(model.isError(any)).thenAnswer((_) => true);
+      when(
+        model.errorMessageFor(any),
+      ).thenAnswer((_) => 'Error During Communication');
+      when(model.fetchFeaturedProjects()).thenReturn(null);
+      when(model.projects).thenAnswer((_) => <Project>[]);
+      when(model.showSearchBar).thenAnswer((_) => false);
+      when(model.previousProjectsBatch).thenAnswer((_) => null);
+
+      await tester.pumpWidget(
+        GetMaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          locale: const Locale('en'),
+          onGenerateRoute: CVRouter.generateRoute,
+          home: const FeaturedProjectsView(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CVException), findsOneWidget);
+      expect(find.text('Error During Communication'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Fixes #84

Describe the changes you have made in this PR -
Added a CVException widget and wired it into the screens that fetch over the network. When a load fails (no internet, API error, etc.) those views now show the error message instead of looking empty.

Screenshots of the changes (If any) -

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent error screens with a cloud-off icon and clear messages across assignment, group, chapter, notification, favourite, project, and featured project views.
  * Empty group states now appear only when data loads successfully without results.

* **Bug Fixes**
  * Improved visibility of fetch and search failures instead of showing blank or misleading content.

* **Tests**
  * Added coverage for the shared error display and featured project error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->