### PR TITLE
fix: silence MSVC experimental coroutine error breaking the Windows build

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -32,6 +32,8 @@ set(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_RELEASE}")
 # Use Unicode for all projects.
 add_definitions(-DUNICODE -D_UNICODE)
 
+add_definitions(-D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+
 # Compilation settings that should be applied to most targets.
 #
 # Be cautious about adding new options here, as plugins use this function by


### PR DESCRIPTION
`Build Validation (windows-latest, windows)` has failed on every CI run since it was added in #428. The runner now ships MSVC 14.51, which turns a coroutine-header deprecation into a hard error (`C2338`/`STL1011`) inside two plugins (`flutter_inappwebview_windows`, `permission_handler_windows`) via C++/WinRT.

```
error C2338: static assertion failed: 'error STL1011: ... You can define
_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS to suppress this error for now.'
```

Fix: define that flag, exactly as the compiler recommends.

Verified on CI combined with #652: `Build Validation (windows-latest, windows)` passed in 9m57s — the first time ever. This PR's own CI will confirm the same once rebased on merged `master`.
