### PR TITLE
fix: correct crowdin trigger branch and arb paths so the sync can run

### DIFF
--- a/.github/workflows/crowdin_sync.yml
+++ b/.github/workflows/crowdin_sync.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: crowdin action
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@v3
         with:
           upload_sources: true
           upload_translations: true

--- a/.github/workflows/crowdin_sync.yml
+++ b/.github/workflows/crowdin_sync.yml
@@ -3,8 +3,8 @@ name: Sync crowdin translation
 on:
   push:
     paths: # run action automatically when app_en.arb file is changed
-      - 'lib/l10n/arb/app_en.arb'
-    branches: [ main ]
+      - 'lib/l10n/app_en.arb'
+    branches: [ master ]
   schedule:
     - cron: '0 */12 * * *'
   workflow_dispatch: 

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,5 +2,5 @@ project_id_env: CROWDIN_PROJECT_ID
 api_token_env: CROWDIN_PERSONAL_TOKEN
 
 files:
-  - source: /lib/l10n/arb/app_en.arb
-    translation: /lib/l10n/arb/app_%two_letters_code%.arb
+  - source: /lib/l10n/app_en.arb
+    translation: /lib/l10n/app_%two_letters_code%.arb


### PR DESCRIPTION

## Problem

Two separate things are wrong with the Crowdin sync.

**1. The push trigger can never fire.** It is scoped to a branch and a path that both do not exist:

```yaml
paths:
  - 'lib/l10n/arb/app_en.arb'   # actual file is lib/l10n/app_en.arb
branches: [ main ]              # this repo's default branch is master
```

So editing the source strings never kicks off a sync. Only the 12-hourly `schedule` ever runs the workflow.

**2. `crowdin.yml` points at a directory that does not exist.** It declares `/lib/l10n/arb/`, but the ARB files live directly in `lib/l10n/`:

```
lib/l10n/app_en.arb
lib/l10n/app_ar.arb
lib/l10n/app_hi.arb
```

This also disagrees with `l10n.yaml`, which correctly sets `arb-dir: lib/l10n`.

**3. The action is a major version behind.** `crowdin/github-action@v2` bundles Crowdin CLI 4.15.1, which nags on every run that 5.0.1 is out.

## Fix

Point both files at the real branch and the real paths. `app_%two_letters_code%.arb` matches the existing `app_ar.arb` / `app_hi.arb` naming.

Also bump the action to `v3` (currently `v3.0.1`). Per the v3 release notes it runs on Crowdin CLI 5 and is a drop-in one-line upgrade; the breaking changes apply only to the `command`, `command_args` and `*_args` inputs, none of which this workflow passes.

