### PR TITLE
ci: require the CI run to pass before dependabot auto-merge

### DIFF
--- a/.github/workflows/dependa_bot_merge.yml
+++ b/.github/workflows/dependa_bot_merge.yml
@@ -4,10 +4,12 @@ on: pull_request
 permissions:
   contents: write
   pull-requests: write
+  actions: read
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'CircuitVerse/mobile-app'
     steps:
       - name: Dependabot metadata
@@ -15,6 +17,29 @@ jobs:
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Wait for CI to pass
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          for _ in $(seq 1 30); do
+            run_id=$(gh run list --workflow ci.yml --commit "$HEAD_SHA" \
+              --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+            [ -n "$run_id" ] && break
+            sleep 20
+          done
+
+          if [ -z "$run_id" ]; then
+            echo "::error::No CI run found for $HEAD_SHA after 10 minutes; refusing to merge."
+            exit 1
+          fi
+
+          echo "Waiting on CI run $run_id for $HEAD_SHA"
+          gh run watch "$run_id" --exit-status
+
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
> **Independent of #652 and #653.** This PR only touches `.github/workflows/dependa_bot_merge.yml` - a workflow that runs on `pull_request` events for dependabot PRs, not on this PR's own commit. The main `CI` workflow will show its normal red/green state for whatever else is on `master` when this runs; that is unrelated to this diff.

## Problem

Dependabot PRs are being merged into `master` with failing CI.

This is not hypothetical - it is how the two dependency breakages fixed in #652 reached `master`:

| PR | CI result | Merged? |
|---|---|---|
| #640 `oauth2_client 4.3.2 -> 4.3.3` | failure | yes (`0724b42` is an ancestor of `master`) |
| #642 `intl 0.20.2 -> 0.20.3` | broke `flutter pub get` for every job | yes |
| #650 `html 0.15.6 -> 0.15.7` | broke compilation of 61 tests | yes |

## Cause

The workflow calls:

```
gh pr merge --auto --merge "$PR_URL"
```

GitHub's auto-merge waits only for status checks that **branch protection marks as required**. It does not wait for "all checks".

This repository has no branch protection and no rulesets:

```
$ gh api repos/CircuitVerse/mobile-app/branches/master --jq .protected
false
$ gh api repos/CircuitVerse/mobile-app/rulesets --jq '.[].name'
(empty)
```

With no required checks, `--auto` merges as soon as the PR is mergeable and CI is ignored entirely. The flag has been a no-op guard.

## Fix

Block on the CI run for the PR's head commit before enabling auto-merge, and fail the job if that run did not succeed.

It waits on the **CI workflow specifically**, not on every check attached to the PR - this workflow is itself one of those checks, so waiting on all of them would deadlock waiting on itself. It also polls for the run to appear first, since CI is queued independently and may not exist the moment this job starts.

`--auto` is kept rather than replaced with a plain `--merge`, so that if branch protection is added later this still defers to it correctly.

Also adds `actions: read` (needed to query run status) and `timeout-minutes: 60` so a stuck CI run cannot pin a runner indefinitely.

## Verification

- Workflow parses as valid YAML; the embedded script passes `bash -n`.
- The run lookup was tested against a real commit:
  ```
  $ gh run list --workflow ci.yml --commit 6c2e575ff7bf4420704da222907eec0e17cb6bfa \
      --limit 1 --json databaseId --jq '.[0].databaseId // empty'
  33738339969
  ```
  which is the correct CI run for that commit. For `pull_request` events the run's `head_sha` is the PR head, which is what `github.event.pull_request.head.sha` provides.
- The merge path itself cannot be exercised until this is on the default branch and a dependabot PR opens.

## This is a workaround, not the real fix

The correct fix is a repository setting that cannot be expressed in a PR: branch protection on `master` with **Require status checks to pass before merging**, listing the CI jobs. That would gate **every** PR rather than only dependabot's, need no workflow code at all, and make the original `--auto` behave as intended.

This PR is the part that can be done from the repository. If an admin enables required status checks, this step becomes redundant and can be reverted.

**Sequencing note:** do not enable required status checks until #653 is merged. The Windows build job currently fails on `master`, so requiring it before that lands would block every PR in the repository.
