### PR TITLE
docs: document the Interactive Book and refresh stale setup details

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,21 +77,20 @@ To point the Interactive Book at a backend running locally:
 flutter run --dart-define=IB_API_BASE_URL=http://localhost:8000/api
 ```
 
-### Android OAuth Config
+### Google Sign-In
 
-#### GitHub Configuration
+For Google OAuth we use [google_sign_in](https://pub.dev/packages/google_sign_in). **No setup is
+needed** — clone, run, and signing in with Google works.
 
-1. `GITHUB_OAUTH_CLIENT_ID`
-2. `GITHUB_OAUTH_CLIENT_SECRET`
+The app requests only the `email` scope and exchanges the resulting access token with the
+CircuitVerse API, so there is no client ID in the source and nothing to configure per machine. The
+OAuth client is registered in Google Cloud Platform against the package name
+(`org.circuitverse.mobile_app`) and the signing certificate's SHA-1 fingerprint; that is maintained
+centrally and does not need repeating for each contributor.
 
-#### Google Configuration
-
-For Google OAuth we use [google_sign_in](https://pub.dev/packages/google_sign_in). You'll require a Java KeyStore(`.jks`)
-
-1. Add `cv_debug.jks` in `android/app/`.
-2. Add `key.debug.properties` in `android/`.
-
-Note: The OAuth Configuration section is not mandatory to get started. To get hold of the above secrets/files drop a message on slack with clear requirements and we'll take care.
+Signing debug builds with a shared certificate is optional: if `android/key.debug.properties` and the
+keystore it points at are present, `android/app/build.gradle` uses them, and falls back to your local
+debug keystore when they are not.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Follow these instructions to build and run the project
 
 ### Prerequisites
 
-- Flutter `3.32.2` (stable)
-- Dart `3.8.1`
+- Flutter `3.44.0` (stable) — the version CI builds against
+- Dart `3.12` (bundled with Flutter)
 
 > Tip: To ensure you’re always using the correct Flutter version, consider using [FVM (Flutter Version Manager)](https://fvm.app/) to manage versions.
 
@@ -58,9 +58,26 @@ flutter run -d chrome --web-browser-flag "--disable-web-security"
 
 > ⚠️ Only use `--disable-web-security` for **local development**. Never use it in production.
 
-### Android OAuth Config
+### Compile-time Configuration
 
-This project uses Flutter 3.32.2 and hence the support for compile-time variables. To use compile-time variables pass them in `--dart-defines` as `flutter run --dart-define=VAR_NAME=VAR_VALUE`. Supported `dart-defines` include :
+This project uses Flutter 3.44.0 and hence the support for compile-time variables. To use compile-time variables pass them in `--dart-defines` as `flutter run --dart-define=VAR_NAME=VAR_VALUE`. Supported `dart-defines` include :
+
+#### API Configuration
+
+Both hosts default to production, so no configuration is needed to get started.
+
+| Variable | Default | Used for |
+| --- | --- | --- |
+| `CV_API_BASE_URL` | `https://circuitverse.org/api/v1` | CircuitVerse REST API |
+| `IB_API_BASE_URL` | `https://learn.circuitverse.org/api` | Interactive Book content API |
+
+To point the Interactive Book at a backend running locally:
+
+```bash
+flutter run --dart-define=IB_API_BASE_URL=http://localhost:8000/api
+```
+
+### Android OAuth Config
 
 #### GitHub Configuration
 
@@ -81,13 +98,20 @@ Note: The OAuth Configuration section is not mandatory to get started. To get ho
 ```bash
 mobile-app/lib/
 ├── config/                         # configuration files like environment_config
+├── controllers/                    # GetX controllers
+|   └── language_controller.dart    # active locale
+├── data/                           # static data tables
 ├── enums/                          # enum files
 |   └── view_state.dart             # defines view states i.e Idle, Busy, Error
 |   └── auth_state.dart             # defines auth states i.e logged in using Google/Github/Email
-├── l10n/                           # localization files like intl_en.arb
-├── locale/                         # AppLocalization & AppLocalizationDelegate
-├── managers/
-|   └── dialog_manager.dart         # show dialogs using dialog navigation key
+├── features/                       # self-contained features
+|   └── interactive-book/           # Interactive Book (see Features below)
+|      ├── models/                  # content API models, one per widget type
+|      ├── services/                # API, chapters, navbar, offline cache, progress
+|      ├── ui/                      # home, navbar, renderer and content widgets
+|      └── root.dart                # entry point and navigation state
+├── gen_l10n/                       # generated localizations (flutter gen-l10n)
+├── l10n/                           # localization files like app_en.arb
 ├── models/                         # model classes
 |   └── dialog_models.dart          # dialog request and response models
         ...
@@ -103,7 +127,7 @@ mobile-app/lib/
 |  └── components/                  # shared components
 ├── utils/                          # utilities such as api_utils routes.dart and styles.dart
 ├── viewmodels/                     # Viewmodels layer
-├── app_theme.dart                  # Shared App Colors/border decorations etc.
+├── cv_theme.dart                   # Shared App Colors/border decorations etc.
 ├── constants.dart                  # App constants
 ├── locator.dart                    # dependency injection using get_it
 ├── main.dart                       # <3 of the app
@@ -132,6 +156,19 @@ mobile-app/lib/
 - Add/Delete Collaborators.
 - Star Project to favourites.
 - View Projects you created/starred.
+
+### Interactive Book
+
+A guided digital logic course, rendered from a structured content API rather than
+bundled with the app.
+
+- Browse chapters and topics from a drawer that tracks reading progress.
+- Progress is stored on the device, so the home screen can resume at the next unread topic.
+- Download the whole book for offline reading, and clear it again from the same card.
+- Work through interactive widgets: a binary simulator, bitwise operators, logic gate
+  switches, character encoding, and inline pop quizzes.
+- Content is served from `IB_API_BASE_URL`, with chapter pages addressed by slug.
+  Requests prefer the network and fall back to the offline cache.
 
 ### Profile
 


### PR DESCRIPTION
Updates the README now that the Interactive Book V2 has landed (#624), and fixes
setup details that had drifted out of date.

### Interactive Book

Adds a feature section covering the book: the chapter drawer and progress
tracking, offline download, the interactive widgets, and where the content comes
from.

### Compile-time configuration

`CV_API_BASE_URL` and `IB_API_BASE_URL` were undocumented — the README only
listed the OAuth defines. Both are now in a table with their defaults, along with
the command for pointing the book at a local backend.

The generic `--dart-define` paragraph sat under **Android OAuth Config**, which
scoped it too narrowly, so it now has its own **Compile-time Configuration**
heading with OAuth as a subsection.

### Authentication

The old steps ("You'll require a Java KeyStore(`.jks`)", add `cv_debug.jks` and
`key.debug.properties`) sent contributors after files they do not need.

Google sign-in works on a plain `flutter run` with no setup. The app requests
only the `email` scope and exchanges the resulting access token with the
CircuitVerse API — there is no `requestIdToken` / `serverClientId`, which is the
case that would require a per-developer Android OAuth client. The section now
says so, and notes that the GCP OAuth client (package name + SHA-1) is
maintained centrally.

The keystore files are documented as genuinely optional, which matches
`android/app/build.gradle` — both signing blocks are guarded by
`if (keystorePropertiesFile.exists())` and fall back to the local debug keystore.

The **GitHub Configuration** subsection is removed: GitHub sign-in is not in use,
and `GITHUB_OAUTH_CLIENT_ID` / `GITHUB_OAUTH_CLIENT_SECRET` have no defaults, so
documenting them only sent contributors looking for secrets they cannot get.
With GitHub gone, the remaining **Android OAuth Config** wrapper held a single
subsection, so it is now just **Google Sign-In**.

### Corrections

| Was | Now |
| --- | --- |
| Flutter `3.32.2`, Dart `3.8.1` | Flutter `3.44.0`, Dart `3.12` — the version CI pins |
| `managers/`, `locale/` | Removed; neither directory exists |
| — | Added `features/`, `controllers/`, `data/`, `gen_l10n/` |
| `app_theme.dart` | `cv_theme.dart` |
| `intl_en.arb` | `app_en.arb` |

Each was verified against the tree rather than assumed: directory listings for
the structure block, `.github/workflows/ci.yml` for the pinned Flutter version,
`lib/config/environment_config.dart` for the variable names and defaults, and
`android/app/build.gradle` for the signing behaviour.

Documentation only — no code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated prerequisites to Flutter 3.44.0 and Dart 3.12.
  - Added documentation for compile-time API configuration.
  - Replaced Android OAuth setup guidance with Google Sign-In instructions.
  - Expanded project structure documentation, including controllers, features, localization files, and theme configuration.
  - Documented the Interactive Book feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->