### PR TITLE
ci: add Indus Appstore deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -179,14 +179,14 @@ jobs:
           echo "${{ secrets.FASTLANE_SUPPLY_JSON_KEY }}" | base64 --decode > android/supply_json_key.json
           
           # Decode and save keystore properties
-          echo "${{ secrets.RELEASE_KEYSTORE_PROPERTIES }}" | base64 --decode > android/key.properties
+          echo "${{ secrets.RELEASE_KEYSTORE_PROPERTIES }}" | base64 --decode > android/key.release.properties
           
           # Decode and save keystore file
           echo "${{ secrets.RELEASE_KEYSTORE }}" | base64 --decode > android/app/cv_release.jks
           
           # Verify files were created
           ls -la android/supply_json_key.json
-          ls -la android/key.properties
+          ls -la android/key.release.properties
           ls -la android/app/cv_release.jks
           
       - name: Cache Gradle
@@ -324,3 +324,12 @@ jobs:
           echo "### 🔗 Links" >> $GITHUB_STEP_SUMMARY
           echo "- [GitHub Release](https://github.com/${{ github.repository }}/releases/tag/v${{ env.VERSION }})" >> $GITHUB_STEP_SUMMARY
           echo "- [Play Console](https://play.google.com/console)" >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload AAB to Indus Appstore
+        if: success()
+        run: |
+          curl --fail-with-body \
+            -X POST \
+            "https://developer-api.indusappstore.com/devtools/aab/upgrade/org.circuitverse.mobile_app" \
+            -H "Authorization: ${{ secrets.INDUS_API_KEY }}" \
+            -F "file=@build/app/outputs/bundle/release/app-release.aab"


### PR DESCRIPTION
Fixes #

Describe the changes you have made in this PR -

- Added a CI step to upload the release AAB to Indus App Store.
- Added authentication using the `INDUS_API_KEY` GitHub secret.
- Fixed the release keystore properties path in the CI workflow to match the Gradle configuration.

Screenshots of the changes (If any) -

N/A

Note: Please check Allow edits from maintainers. if you would like us to assist in the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release builds are now automatically uploaded to the Indus Appstore after successful completion.

* **Bug Fixes**
  * Improved release signing configuration verification for Android builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->